### PR TITLE
Fix incorrect derivation of timestep in rAF loop.

### DIFF
--- a/src/animation/gravity.ts
+++ b/src/animation/gravity.ts
@@ -78,15 +78,23 @@ export const gravity1D = (params: Gravity1DParams) => {
      * and the last frame. If more than four frames have been dropped, assuming
      * a 60fps interval, just use the timestamp of the current frame.
      */
-    const diffTime = timestamp > lastFrame + 64 ? 0 : lastFrame;
-    const steps = Math.floor(timestamp - diffTime);
 
-    if (steps > 0) {
-      // Apply the gravitational force once for each step.
-      for (let i = 0; i < steps; i++) {
-        state.mover = applyForceForStep(state);
-      }
-    } else {
+    // Obtain the timestamp of the last frame. If this is the first frame, use the current frame timestamp.
+    let lastTime = lastFrame !== undefined ? lastFrame : timestamp;
+
+    /**
+     * If more than four frames have been dropped since the last frame,
+     * just use the current frame timestamp.
+     */
+    if (timestamp > lastTime + 64) {
+      lastTime = timestamp;
+    }
+
+    // Determine the number of steps between the current frame and last recorded frame.
+    const steps = Math.floor(timestamp - lastTime);
+
+    // Apply the gravitational force once for each step.
+    for (let i = 0; i < steps; i++) {
       state.mover = applyForceForStep(state);
     }
 
@@ -158,16 +166,25 @@ export const gravity2D = (
      * and the last frame. If more than four frames have been dropped, assuming
      * a 60fps interval, just use the timestamp of the current frame.
      */
-    const diffTime = timestamp > lastFrame + 64 ? 0 : lastFrame;
-    const steps = Math.floor(timestamp - diffTime);
 
-    if (steps > 0) {
-      // Apply the gravitational force once for each step.
-      for (let i = 0; i < steps; i++) {
-        state.mover = applyForceForStep(state, params.config.threshold);
-      }
-    } else {
-      state.mover = applyForceForStep(state, params.config.threshold);
+    // Obtain the timestamp of the last frame. If this is the first frame, use the current frame timestamp.
+    let lastTime = lastFrame !== undefined ? lastFrame : timestamp;
+
+    /**
+     * If more than four frames have been dropped since the last frame,
+     * just use the current frame timestamp.
+     */
+
+    if (timestamp > lastTime + 64) {
+      lastTime = timestamp;
+    }
+
+    // Determine the number of steps between the current frame and last recorded frame.
+    const steps = Math.floor(timestamp - lastTime);
+
+    // Apply the gravitational force once for each step.
+    for (let i = 0; i < steps; i++) {
+      state.mover = applyForceForStep(state);
     }
 
     params.onUpdate({

--- a/stories/useGravity.stories.tsx
+++ b/stories/useGravity.stories.tsx
@@ -30,7 +30,7 @@ export const GravityBackground: React.FC = () => {
     config: {
       moverMass: number('moverMass', 100000),
       attractorMass: number('attractorMass', 1000000000),
-      r: number('r', 150),
+      r: number('r', 50),
     },
   });
 
@@ -39,8 +39,8 @@ export const GravityBackground: React.FC = () => {
 
 export const GravityTranslateX: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
-    from: { transform: 'translateX(0px)' },
-    to: { transform: 'translateX(300px)' },
+    from: { transform: 'translateX(0px) translate(-50%, -50%)' },
+    to: { transform: 'translateX(300px) translate(-50%, -50%)' },
     config: {
       moverMass: number('moverMass', 100000),
       attractorMass: number('attractorMass', 1000000000),
@@ -53,8 +53,8 @@ export const GravityTranslateX: React.FC = () => {
 
 export const GravityRotate: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
-    from: { transform: 'rotate(0deg)' },
-    to: { transform: 'rotate(360deg)' },
+    from: { transform: 'rotate(0deg) translate(-50%, -50%)' },
+    to: { transform: 'rotate(360deg) translate(-50%, -50%)' },
     config: {
       moverMass: number('moverMass', 100000),
       attractorMass: number('attractorMass', 1000000000),

--- a/stories/useGravity2D.stories.tsx
+++ b/stories/useGravity2D.stories.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { withKnobs, number } from '@storybook/addon-knobs';
 
 import { useGravity2D, vector as Vector } from '../src';
 import './useGravity2D.css';
 
 export default {
   title: 'Gravity2D',
+  decorators: [withKnobs],
 };
 
 export const Gravity2D: React.FC = () => {
@@ -19,13 +21,17 @@ export const Gravity2D: React.FC = () => {
 
   const [props] = useGravity2D({
     config: {
-      attractorMass: 100000000000,
-      moverMass: 20000000,
+      attractorMass: number('attractorMass', 100000000000),
+      moverMass: number('moverMass', 20000000),
       attractorPosition: center,
-      initialMoverVelocity: [0.1, 0.2],
+      initialMoverPosition: [center[0] - 200, center[1] - 200],
+      initialMoverVelocity: [
+        number('initialMoverVelocityX', 0.1),
+        number('initialMoverVelocityY', 0),
+      ],
       threshold: {
-        min: 10,
-        max: 100,
+        min: number('thresholdMin', 10),
+        max: number('thresholdMax', 100),
       },
     },
   });


### PR DESCRIPTION
This PR fixes a pretty egregious issue with our timestep calculations that get executed in each `rAF` loop. Previously, we were incorrectly calculating the number of milliseconds (`steps` in the code below) between the previous frame and the current frame. This only happened, however, when more than four frames were dropped and we got 0 as our `diffTime`. This could result in _incredibly_ high numbers being derived for the number of steps to use to calculate force. For example:

- We drop four frames, perhaps from changing a Storybook story and the time it takes for React to unmount and mount a new component 😉 
- `timestamp` is the ms since epoch of the current frame, but `diffTime` is 0. Many seconds - 0 = many seconds.
- Uh oh, we're applying the force _way_ too many times 😱 

This PR fixes that issue, which gives us nice, smooth animations that successfully continue to run, even in the background. I previously only noticed it sporadically b/c we had to drop more than four frames to hit this condition, but it was happening quite regularly on Storybook. With these changes, we can change stories and see all `from` / `to` animations immediately restart smoothly. Thanks @bmathews for doing some debugging with me, which eventually lead me down the right path of interrogating this bit of code.