### PR TITLE
Add support for immediate and delay properties. Move start and stop into the controller.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
     'react/no-unescaped-entities': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 };

--- a/__tests__/force/Friction_test.re
+++ b/__tests__/force/Friction_test.re
@@ -44,7 +44,7 @@ describe("Friction", () => {
         expect(
           Friction.getMaxDistanceFriction(~mu=0.1, ~initialVelocity=50.),
         )
-        |> toBeCloseTo(1274.65)
+        |> toBeCloseTo(1274645266.22)
       )
     )
   );

--- a/src/animation/friction.ts
+++ b/src/animation/friction.ts
@@ -1,15 +1,13 @@
 import { rAF } from '../rAF';
 import { Entity, applyForce, frictionForceV } from '../forces';
-import { VectorSetter, Controller } from './types';
+import { Listener, AnimationParams, AnimationInitializer } from './types';
 
-export interface Friction1DParams {
+export interface Friction1DParams extends AnimationParams {
   config: {
     mu: number;
     mass: number;
     initialVelocity: number;
   };
-  onUpdate: VectorSetter;
-  onComplete: () => void;
 }
 
 interface FrictionState {
@@ -41,18 +39,17 @@ const applyFrictionForceForStep = (
  */
 export const friction1D = (
   params: Friction1DParams
-): { controller: Controller } => {
+): { controller: AnimationInitializer } => {
   const state: FrictionState = {
     mover: {
       mass: params.config.mass,
       acceleration: [0, 0],
-      velocity: [params.config.initialVelocity, 0],
+      velocity: [params.config.initialVelocity * 1000, 0],
       position: [0, 0],
     },
   };
 
-  const { start } = rAF();
-  const { stop } = start((timestamp, lastFrame, stop) => {
+  const listener: Listener = (timestamp, lastFrame, stop) => {
     /**
      * Determine the number of milliseconds elapsed between the current frame
      * and the last frame. If more than four frames have been dropped, assuming
@@ -92,7 +89,10 @@ export const friction1D = (
         position: state.mover.position,
       });
     }
-  });
+  };
 
-  return { controller: { start, stop } };
+  const { start } = rAF();
+  const runAnimation = () => start(listener);
+
+  return { controller: { start: runAnimation } };
 };

--- a/src/animation/friction.ts
+++ b/src/animation/friction.ts
@@ -44,6 +44,7 @@ export const friction1D = (
     mover: {
       mass: params.config.mass,
       acceleration: [0, 0],
+      // Initial velocity is provided in m / ms. Multiply by 1000 to derive m / s.
       velocity: [params.config.initialVelocity * 1000, 0],
       position: [0, 0],
     },

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -5,13 +5,23 @@ export type VectorSetter = (values: {
   velocity?: Vector<number>;
 }) => void;
 
-type Listener = (
-  timestamp: number,
-  lastFrame: number,
+export type Listener = (
+  timestamp: DOMHighResTimeStamp,
+  lastFrame: DOMHighResTimeStamp,
   stop: () => void
 ) => void;
 
-export interface Controller {
-  start: (listener: Listener) => void;
+export interface AnimationInitializer {
+  start: () => { stop: () => void };
+}
+
+export interface Controller extends AnimationInitializer {
   stop: () => void;
+}
+
+export interface AnimationParams {
+  onUpdate: VectorSetter;
+  onComplete: () => void;
+  immediate?: boolean;
+  delay?: number;
 }

--- a/src/forces/Friction.bs.js
+++ b/src/forces/Friction.bs.js
@@ -16,7 +16,7 @@ function frictionForceV(mu, mass, velocity) {
 
 function getMaxDistanceFriction(mu, initialVelocity) {
   var accelerationF = -1 * mu * Gravity.gE;
-  return $$Math.sqf(initialVelocity) / (-2 * accelerationF);
+  return $$Math.sqf(initialVelocity * 1000) / (-2 * accelerationF);
 }
 
 export {

--- a/src/forces/Friction.re
+++ b/src/forces/Friction.re
@@ -5,6 +5,8 @@ let frictionForceMag = (~mu, ~mass) => {
 
 // The frictional force vector.
 let frictionForceV = (~mu, ~mass, ~velocity) => {
+  // let velocity = Vector.multf(~v=velocity, ~s=1000.);
+
   // Derive the magnitude of the frictive force.
   let mag = frictionForceMag(~mu, ~mass);
 
@@ -18,8 +20,13 @@ let frictionForceV = (~mu, ~mass, ~velocity) => {
   Vector.multf(~v=dir, ~s=mag);
 };
 
-// The kinematic equation for deriving distance traveled by a body to reach rest assuming constant acceleration.
+/**
+ * The kinematic equation for deriving distance traveled
+ * by a body to reach rest assuming constant acceleration.
+ */
 let getMaxDistanceFriction = (~mu, ~initialVelocity) => {
   let accelerationF = (-1.) *. mu *. Gravity.gE;
-  Math.sqf(initialVelocity) /. ((-2.) *. accelerationF);
+
+  // Initial velocity is provided in m / ms. Multiply by 1000 to derive m / s.
+  Math.sqf(initialVelocity *. 1000.) /. ((-2.) *. accelerationF);
 };

--- a/src/helpers/pairs.ts
+++ b/src/helpers/pairs.ts
@@ -149,3 +149,12 @@ export function getInterpolatorForPair({ from, to }: CSSPairs) {
     },
   };
 }
+
+export function getInterpolatorsForPairs({ from, to }: CSSPairs) {
+  return Object.keys(from).map(key => {
+    const f = { [key]: (from as { [cssProperty: string]: any })[key] };
+    const t = { [key]: (to as { [cssProperty: string]: any })[key] };
+
+    return getInterpolatorForPair({ from: f, to: t });
+  });
+}

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -1,16 +1,18 @@
 import React from 'react';
 
-import { CSSPairs, getInterpolatorForPair } from '../helpers/pairs';
+import { CSSPairs, getInterpolatorsForPairs } from '../helpers/pairs';
 import { Friction1DParams, friction1D, Controller } from '../animation';
 import { getMaxDistanceFriction } from '../forces';
 
 type UseFrictionArgs = CSSPairs &
-  Omit<Friction1DParams, 'onUpdate' | 'onComplete'>;
+  Omit<Friction1DParams, 'onComplete' | 'onUpdate'>;
 
 export const useFriction = <M extends HTMLElement>({
   from,
   to,
   config,
+  immediate = true,
+  delay,
 }: UseFrictionArgs): [
   { ref: React.MutableRefObject<M | null> },
   Controller
@@ -23,42 +25,76 @@ export const useFriction = <M extends HTMLElement>({
    */
   const ref = React.useRef<M>(null);
 
+  /**
+   * Store a ref to the controller. This will allow a user to
+   * start and stop animations at will.
+   */
+  const controllerRef = React.useRef<Controller>({
+    start: () => ({ stop: () => {} }),
+    stop: () => {},
+  });
+
   const { controller } = React.useMemo(() => {
-    const { interpolator, property, values } = getInterpolatorForPair({
-      from,
-      to,
-    });
+    const interpolators = getInterpolatorsForPairs({ from, to });
 
     return friction1D({
       config,
       onUpdate: ({ position }) => {
-        const value = interpolator({
-          range: [
-            0,
-            getMaxDistanceFriction({
-              mu: config.mu,
-              initialVelocity: config.initialVelocity,
-            }),
-          ],
-          domain: [values.from, values.to],
-          value: position[0],
-        });
+        interpolators.forEach(({ interpolator, property, values }) => {
+          const value = interpolator({
+            range: [
+              0,
+              getMaxDistanceFriction({
+                mu: config.mu,
+                initialVelocity: config.initialVelocity * 1000,
+              }),
+            ],
+            domain: [values.from, values.to],
+            value: position[0],
+          });
 
-        if (ref.current) {
-          ref.current.style[property as any] = `${value}`;
-        }
+          if (ref.current) {
+            ref.current.style[property as any] = `${value}`;
+          }
+        });
       },
       onComplete: () => {
         /**
          * Ensure our animation has reached the to value when the physics stopping
          * condition has been reached.
          */
-        if (ref.current && ref.current.style[property as any] !== values.to) {
-          ref.current.style[property as any] = values.to;
-        }
+        interpolators.forEach(({ property, values }) => {
+          if (ref.current && ref.current.style[property as any] !== values.to) {
+            ref.current.style[property as any] = values.to;
+          }
+        });
       },
     });
   }, [from, to, config]);
 
-  return [{ ref }, controller];
+  controllerRef.current = {
+    ...controllerRef.current,
+    ...controller,
+  };
+
+  React.useLayoutEffect(() => {
+    if (immediate && !delay) {
+      const { stop } = controller.start();
+      controllerRef.current.stop = stop;
+    }
+
+    let timerId: number;
+    if (immediate && delay) {
+      timerId = setTimeout(() => {
+        const { stop } = controller.start();
+        controllerRef.current.stop = stop;
+      }, delay);
+    }
+
+    return () => {
+      timerId && clearTimeout(timerId);
+    };
+  }, [immediate, controller]);
+
+  return [{ ref }, controllerRef.current];
 };

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -29,10 +29,6 @@ export const useFriction = <M extends HTMLElement>({
    * Store a ref to the controller. This will allow a user to
    * start and stop animations at will.
    */
-  const controllerRef = React.useRef<Controller>({
-    start: () => ({ stop: () => {} }),
-    stop: () => {},
-  });
 
   const { controller } = React.useMemo(() => {
     const interpolators = getInterpolatorsForPairs({ from, to });
@@ -72,10 +68,10 @@ export const useFriction = <M extends HTMLElement>({
     });
   }, [from, to, config]);
 
-  controllerRef.current = {
-    ...controllerRef.current,
-    ...controller,
-  };
+  const controllerRef = React.useRef<Controller>({
+    start: controller.start,
+    stop: () => {},
+  });
 
   React.useLayoutEffect(() => {
     if (immediate && !delay) {

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -90,7 +90,7 @@ export const useFriction = <M extends HTMLElement>({
     return () => {
       timerId && clearTimeout(timerId);
     };
-  }, [immediate, controller]);
+  }, [immediate, delay, controller]);
 
   return [{ ref }, controllerRef.current];
 };

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -25,11 +25,6 @@ export const useFriction = <M extends HTMLElement>({
    */
   const ref = React.useRef<M>(null);
 
-  /**
-   * Store a ref to the controller. This will allow a user to
-   * start and stop animations at will.
-   */
-
   const { controller } = React.useMemo(() => {
     const interpolators = getInterpolatorsForPairs({ from, to });
 
@@ -42,7 +37,7 @@ export const useFriction = <M extends HTMLElement>({
               0,
               getMaxDistanceFriction({
                 mu: config.mu,
-                initialVelocity: config.initialVelocity * 1000,
+                initialVelocity: config.initialVelocity,
               }),
             ],
             domain: [values.from, values.to],
@@ -68,6 +63,10 @@ export const useFriction = <M extends HTMLElement>({
     });
   }, [from, to, config]);
 
+  /**
+   * Store a ref to the controller. This will allow a user to
+   * start and stop animations at will.
+   */
   const controllerRef = React.useRef<Controller>({
     start: controller.start,
     stop: () => {},

--- a/src/rAF/index.ts
+++ b/src/rAF/index.ts
@@ -1,11 +1,9 @@
+import { Listener } from '../animation';
+
 interface RAFState {
   lastFrame: DOMHighResTimeStamp;
   animationFrameId: number | null;
-  listener: (
-    timestamp: DOMHighResTimeStamp,
-    lastFrame: DOMHighResTimeStamp,
-    stop: () => void
-  ) => void;
+  listener: Listener;
 }
 
 export const rAF = () => {

--- a/stories/button.css
+++ b/stories/button.css
@@ -1,0 +1,26 @@
+button {
+  display: inline-block;
+  border: none;
+  padding: 1rem 2rem;
+  margin: 0;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.button {
+  position: relative;
+  left: 50%;
+  top: 35%;
+  transform: translate(-50%, -50%);
+  background: var(--color-near-black);
+  color: rgba(255, 255, 255, 0.8);
+  box-shadow: 0px 10px 30px -5px rgba(0, 0, 0, 0.2);
+  font-size: 1em;
+  font-weight: 700;
+  border-radius: 5px;
+  transition: transform 0.2s ease;
+}
+
+.button:hover {
+  transform: translate(-50%, -50%) scale(1.1);
+}

--- a/stories/index.css
+++ b/stories/index.css
@@ -13,6 +13,11 @@
   --color-deep-blue: #053959;
 }
 
+body {
+  font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir,
+    helvetica neue, helvetica, ubuntu, roboto, noto, segoe ui, arial, sans-serif;
+}
+
 #root {
   position: absolute;
   top: 0;
@@ -34,7 +39,8 @@
   height: 100px;
   width: 100px;
   transform: translate(-50%, -50%);
-  border-radius: 50%;
+  border-radius: 10px;
+  transform-origin: top left;
 }
 
 .mover--opacity {

--- a/stories/toggle.css
+++ b/stories/toggle.css
@@ -1,0 +1,59 @@
+.toggle {
+  position: relative;
+  left: 50%;
+  top: 35%;
+  width: 55px;
+  transform: translate(-50%, -50%);
+}
+
+.toggle input {
+  opacity: 0;
+  position: absolute;
+}
+
+.toggle input + label {
+  position: relative;
+  display: inline-block;
+  user-select: none;
+  height: 30px;
+  width: 50px;
+  border: 1px solid #e4e4e4;
+  border-radius: 60px;
+  transition: 0.4s ease;
+}
+
+.toggle input + label::before {
+  content: '';
+  position: absolute;
+  display: block;
+  height: 30px;
+  width: 51px;
+  top: 0;
+  left: 0;
+  border-radius: 30px;
+  transition: 0.2s cubic-bezier(0.24, 0, 0.5, 1);
+}
+
+.toggle input + label::after {
+  content: '';
+  position: absolute;
+  display: block;
+  background: var(--color-orange);
+  height: 28px;
+  width: 28px;
+  top: 1px;
+  left: 0px;
+  border-radius: 60px;
+  box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.1), 0 4px 0px 0 hsla(0, 0%, 0%, 0.04),
+    0 4px 9px hsla(0, 0%, 0%, 0.13), 0 3px 3px hsla(0, 0%, 0%, 0.05);
+  transition: 0.35s cubic-bezier(0.54, 1.6, 0.5, 1);
+}
+
+.toggle input:checked + label::before {
+  transition: width 0.2s cubic-bezier(0, 0, 0, 0.1);
+  background: var(--color-near-black);
+}
+
+.toggle input:checked + label::after {
+  left: 24px;
+}

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -3,49 +3,94 @@ import { withKnobs, number } from '@storybook/addon-knobs';
 
 import { useFriction } from '../src';
 import './index.css';
+import './toggle.css';
+import './button.css';
 
 export default {
   title: 'Friction',
   decorators: [withKnobs],
 };
 
-export const FrictionOpacity: React.FC = () => {
+export const FrictionMultiple: React.FC = () => {
+  const [toggle, setToggle] = React.useState(true);
+
   const [props] = useFriction<HTMLDivElement>({
-    from: { opacity: 0 },
-    to: { opacity: 1 },
+    from: {
+      opacity: toggle ? 0 : 1,
+      transform: toggle
+        ? 'scale(0) rotate(0deg) translate(-50%, -50%)'
+        : 'scale(1) rotate(180deg) translate(-50%, -50%)',
+    },
+    to: {
+      opacity: toggle ? 1 : 0,
+      transform: toggle
+        ? 'scale(1) rotate(180deg) translate(-50%, -50%)'
+        : 'scale(0) rotate(0deg) translate(-50%, -50%)',
+    },
     config: {
       mu: number('mu', 0.25),
       mass: number('mass', 50),
-      initialVelocity: number('initialVelocity', 5000),
+      initialVelocity: number('initialVelocity', 5),
     },
   });
 
-  return <div className="mover mover--opacity" {...props} />;
+  return (
+    <>
+      <div className="toggle">
+        <input
+          type="checkbox"
+          name="toggle"
+          id="toggle"
+          checked={toggle}
+          onChange={() => {
+            setToggle(prevToggle => !prevToggle);
+          }}
+        />
+        <label htmlFor="toggle"></label>
+      </div>
+      <div className="mover mover--opacity" {...props} />
+    </>
+  );
 };
 
 export const FrictionTranslateX: React.FC = () => {
-  const [props] = useFriction<HTMLDivElement>({
+  const [props, controller] = useFriction<HTMLDivElement>({
     from: { transform: 'translateX(0px) translate(-50%, -50%)' },
     to: { transform: 'translateX(300px) translate(-50%, -50%)' },
     config: {
-      mu: number('mu', 0.05),
+      mu: number('mu', 0.5),
       mass: number('mass', 300),
-      initialVelocity: number('velocity', 1000),
+      initialVelocity: number('velocity', 10),
     },
+    immediate: false,
   });
 
-  return <div className="mover mover--translate" {...props} />;
+  return (
+    <>
+      <button className="button" onClick={controller.start}>
+        Run Animation
+      </button>
+      <div className="mover mover--translate" {...props} />
+    </>
+  );
 };
 
-export const FrictionTransformMultiple: React.FC = () => {
+export const FrictionTransform: React.FC = () => {
   const [props] = useFriction<HTMLDivElement>({
-    from: { transform: 'translate(0px, 200px) translate(-50%, -50%)' },
-    to: { transform: 'translate(400px, -200px) translate(-50%, -50%)' },
-    config: {
-      mu: number('mu', 0.05),
-      mass: number('mass', 300),
-      initialVelocity: number('velocity', 1000),
+    from: {
+      background: '#f25050',
+      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
     },
+    to: {
+      background: '#a04ad9',
+      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+    },
+    config: {
+      mu: number('mu', 0.5),
+      mass: number('mass', 300),
+      initialVelocity: number('velocity', 10),
+    },
+    delay: 2000,
   });
 
   return <div className="mover mover--translate" {...props} />;

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -75,7 +75,7 @@ export const FrictionTranslateX: React.FC = () => {
   );
 };
 
-export const FrictionTransform: React.FC = () => {
+export const FrictionTransformDelay: React.FC = () => {
   const [props] = useFriction<HTMLDivElement>({
     from: {
       background: '#f25050',

--- a/stories/useGravity.stories.tsx
+++ b/stories/useGravity.stories.tsx
@@ -67,8 +67,8 @@ export const GravityRotate: React.FC = () => {
 
 export const GravityScale: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
-    from: { transform: 'scale(1, 1)' },
-    to: { transform: 'scale(2, 4)' },
+    from: { transform: 'scale(1, 1) translate(-50%, -50%)' },
+    to: { transform: 'scale(2, 4) translate(-50%, -50%)' },
     config: {
       moverMass: number('moverMass', 100000),
       attractorMass: number('attractorMass', 1000000000),
@@ -83,11 +83,11 @@ export const GravityTransformMultiple: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
     from: {
       transform:
-        'scale(1, 1) rotate(0deg) translate(0px, 0px) skew(0deg, 0deg)',
+        'scale(1, 1) rotate(0deg) translate(0px, 0px) skew(0deg, 0deg) translate(-50%, -50%)',
     },
     to: {
       transform:
-        'scale(4, 4) rotate(180deg) translate(-50px, 50px) skew(30deg, 70deg)',
+        'scale(4, 4) rotate(180deg) translate(-50px, 50px) skew(30deg, 70deg) translate(-50%, -50%)',
     },
     config: {
       moverMass: number('moverMass', 100000),


### PR DESCRIPTION
This PR adds support for what I'm calling the "controller" API. Basically, a `controller` allows a user to start and stop their animations arbitrarily. It works this:

```typescript
const [props, controller] = useFriction<HTMLDivElement>({
  from: { transform: 'translateX(0px) translate(-50%, -50%)' },
  to: { transform: 'translateX(300px) translate(-50%, -50%)' },
  config: {
    mu: 0.5,
    mass: 300,
    initialVelocity: 10,
  },
  // By default, all animations will run immediately on component mount.
  // This instructs the hook to wait until controller.start has been called.
  immediate: false,
});

return (
  <>
    // In onClick we call `controller.start` to begin the animation. You also have access to controller.stop.
    <button className="button" onClick={controller.start}>
      Run Animation
    </button>
    <div className="mover mover--translate" {...props} />
  </>
);
```

This is great, because we can now arbitrarily start and stop animations in response to events! I did decide to default the `immediate` option to `true`, because I imagine most users will expect the animation to run immediately with no additional configuration.

This PR also adds a `delay` option to the configuration. `delay` queues an animation to run after a specified timeout. Currently, there's only support for delaying an animation that doesn't wait for a user event to actually initiate it. I plan to fix this in an upcoming PR, but I want to get some feedback on this approach first.

Finally, I added support for interpolating multiple CSS properties simultaneously 🎉 This means users can now do things like:

```typescript
from: {
   opacity: 0,
   transform: 'scale(0) rotate(0deg)'
},
to: {
  opacity: 1,
  transform: 'scale(1) rotate(180deg)'
}
```

We're now able to do some pretty nifty stuff!

![200102_friction_toggle](https://user-images.githubusercontent.com/19421190/71695993-a5d0e180-2d68-11ea-8bfe-1e237f05ce72.gif)
