### PR TITLE
Fallback to Date.now in Node environments in lieu of performance.now.

### DIFF
--- a/src/rAF/index.ts
+++ b/src/rAF/index.ts
@@ -8,7 +8,7 @@ interface RAFState {
 
 export const rAF = () => {
   const state: RAFState = {
-    lastFrame: performance.now(),
+    lastFrame: typeof window !== 'undefined' ? performance.now() : Date.now(),
     animationFrameId: null,
     listener: ((() => {}) as unknown) as RAFState['listener'],
   };


### PR DESCRIPTION
Fix #53 

This PR should address issues with using `renature` in Node environments, specifically for server-side rendering with Next.js. The sole issue with our hooks is that they use `performance.now` for tracking frame timestamps, which will be `undefined` in Node environments. To fix this we now use `Date.now` in Node environments for the initial server-side render. Everything appears to be working well now – here's a `renature` animation running in a Next starter app.

![image](https://user-images.githubusercontent.com/19421190/81482379-cbc53180-91f3-11ea-8369-c79c5904eaef.png)

Does anyone see issues with this approach? Is there some obvious bug I'm missing? As far as I know `react-spring` always uses `Date.now` for the same reason. I prefer to use `performance.now` for our browser-only client-side SPA friends and gracefully fallback to `Date.now` for the SSR masses.