### PR TITLE
Add proposal for onFrame and onAnimationComplete APIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@typescript-eslint/parser": "^2.11.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
-    "bs-platform": "^7.2.2",
+    "bs-platform": "^7.3.2",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-react": "^7.17.0",

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -25,6 +25,8 @@ export interface AnimationParams {
   immediate?: boolean;
   delay?: number;
   infinite?: boolean;
+  onFrame?: (progress: number) => void;
+  onAnimationComplete?: (progress: number) => void;
 }
 
 export enum PlayState {

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -26,7 +26,7 @@ export interface AnimationParams {
   delay?: number;
   infinite?: boolean;
   onFrame?: (progress: number) => void;
-  onAnimationComplete?: (progress: number) => void;
+  onAnimationComplete?: () => void;
 }
 
 export enum PlayState {

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -66,7 +66,7 @@ export const useFriction = <M extends HTMLElement | SVGElement = any>({
           }
 
           if (onAnimationComplete) {
-            onAnimationComplete(1);
+            onAnimationComplete();
           }
         });
       },

--- a/stories/components/button.css
+++ b/stories/components/button.css
@@ -9,18 +9,16 @@ button {
 
 .button {
   position: relative;
-  left: 50%;
-  top: 35%;
-  transform: translate(-50%, -50%);
   background: var(--color-near-black);
   color: rgba(255, 255, 255, 0.8);
   box-shadow: 0px 10px 30px 5px rgba(0, 0, 0, 0.2);
   font-size: 1em;
   font-weight: 700;
   border-radius: 5px;
+  margin: 20px;
   transition: transform 0.2s ease;
 }
 
 .button:hover {
-  transform: translate(-50%, -50%) scale(1.1);
+  transform: scale(1.1);
 }

--- a/stories/components/toggle.css
+++ b/stories/components/toggle.css
@@ -1,9 +1,7 @@
 .toggle {
   position: relative;
-  left: 50%;
-  top: 35%;
   width: 55px;
-  transform: translate(-50%, -50%);
+  margin: 20px;
 }
 
 .toggle input {

--- a/stories/index.css
+++ b/stories/index.css
@@ -25,6 +25,9 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .space {
@@ -34,14 +37,10 @@ body {
 }
 
 .mover {
-  position: relative;
-  top: 50%;
-  left: 50%;
   height: 100px;
   width: 100px;
-  transform: translate(-50%, -50%);
   border-radius: 10px;
-  transform-origin: top left;
+  transform-origin: center;
 }
 
 .mover--opacity {

--- a/stories/useFluidResistance.stories.tsx
+++ b/stories/useFluidResistance.stories.tsx
@@ -13,10 +13,10 @@ export default {
 export const FluidResistanceBasic: React.FC = () => {
   const [props] = useFluidResistance<HTMLDivElement>({
     from: {
-      transform: 'translateY(-200%) translate(-50%, -50%)',
+      transform: 'translateY(-200%)',
     },
     to: {
-      transform: 'translateY(200%) translate(-50%, -50%)',
+      transform: 'translateY(200%)',
     },
     config: {
       mass: number('mass', 25),
@@ -36,15 +36,11 @@ export const FluidResistanceControlled: React.FC = () => {
   const [props] = useFluidResistance<HTMLDivElement>({
     from: {
       opacity: toggle ? 0 : 1,
-      transform: toggle
-        ? 'scale(0) rotate(0deg) translate(-50%, -50%)'
-        : 'scale(1) rotate(180deg) translate(-50%, -50%)',
+      transform: toggle ? 'scale(0) rotate(0deg)' : 'scale(1) rotate(180deg)',
     },
     to: {
       opacity: toggle ? 1 : 0,
-      transform: toggle
-        ? 'scale(1) rotate(180deg) translate(-50%, -50%)'
-        : 'scale(0) rotate(0deg) translate(-50%, -50%)',
+      transform: toggle ? 'scale(1) rotate(180deg)' : 'scale(0) rotate(0deg)',
     },
     config: {
       mass: number('mass', 25),
@@ -70,8 +66,8 @@ export const FluidResistanceControlled: React.FC = () => {
 
 export const FluidResistanceEventBased: React.FC = () => {
   const [props, controller] = useFluidResistance<HTMLDivElement>({
-    from: { transform: 'translateX(0px) translate(-50%, -50%)' },
-    to: { transform: 'translateX(300px) translate(-50%, -50%)' },
+    from: { transform: 'translateX(0px)' },
+    to: { transform: 'translateX(300px)' },
     config: {
       mass: number('mass', 25),
       rho: number('rho', 10),
@@ -94,11 +90,11 @@ export const FluidResistanceDelay: React.FC = () => {
   const [props] = useFluidResistance<HTMLDivElement>({
     from: {
       background: '#f25050',
-      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
+      transform: 'scale(1) rotate(0deg)',
     },
     to: {
       background: '#a04ad9',
-      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+      transform: 'scale(1.5) rotate(720deg)',
     },
     config: {
       mass: number('mass', 25),
@@ -117,11 +113,11 @@ export const FluidResistanceInfinite: React.FC = () => {
   const [props] = useFluidResistance<HTMLDivElement>({
     from: {
       background: '#f25050',
-      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
+      transform: 'scale(1) rotate(0deg)',
     },
     to: {
       background: '#a04ad9',
-      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+      transform: 'scale(1.5) rotate(720deg)',
     },
     config: {
       mass: number('mass', 25),

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { withKnobs, number } from '@storybook/addon-knobs';
 
 import { useFriction } from '../src';
@@ -36,15 +36,11 @@ export const FrictionControlled: React.FC = () => {
   const [props] = useFriction<HTMLDivElement>({
     from: {
       opacity: toggle ? 0 : 1,
-      transform: toggle
-        ? 'scale(0) rotate(0deg) translate(-50%, -50%)'
-        : 'scale(1) rotate(180deg) translate(-50%, -50%)',
+      transform: toggle ? 'scale(0) rotate(0deg)' : 'scale(1) rotate(180deg)',
     },
     to: {
       opacity: toggle ? 1 : 0,
-      transform: toggle
-        ? 'scale(1) rotate(180deg) translate(-50%, -50%)'
-        : 'scale(0) rotate(0deg) translate(-50%, -50%)',
+      transform: toggle ? 'scale(1) rotate(180deg)' : 'scale(0) rotate(0deg)',
     },
     config: {
       mu: number('mu', 0.25),
@@ -68,8 +64,8 @@ export const FrictionControlled: React.FC = () => {
 
 export const FrictionEventBased: React.FC = () => {
   const [props, controller] = useFriction<HTMLDivElement>({
-    from: { transform: 'translateX(0px) translate(-50%, -50%)' },
-    to: { transform: 'translateX(300px) translate(-50%, -50%)' },
+    from: { transform: 'translateX(0px)' },
+    to: { transform: 'translateX(300px)' },
     config: {
       mu: number('mu', 0.5),
       mass: number('mass', 300),
@@ -90,11 +86,11 @@ export const FrictionDelay: React.FC = () => {
   const [props] = useFriction<HTMLDivElement>({
     from: {
       background: '#f25050',
-      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
+      transform: 'scale(1) rotate(0deg)',
     },
     to: {
       background: '#a04ad9',
-      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+      transform: 'scale(1.5) rotate(720deg)',
     },
     config: {
       mu: number('mu', 0.5),
@@ -111,11 +107,11 @@ export const FrictionInfinite: React.FC = () => {
   const [props] = useFriction<HTMLDivElement>({
     from: {
       background: '#f25050',
-      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
+      transform: 'scale(1) rotate(0deg)',
     },
     to: {
       background: '#a04ad9',
-      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+      transform: 'scale(1.5) rotate(720deg)',
     },
     config: {
       mu: number('mu', 0.5),
@@ -266,4 +262,34 @@ export const FrictionSVG: React.FC = () => {
       />
     </svg>
   );
+};
+
+export const FrictionProgress: React.FC = () => {
+  const progressRef = useRef<HTMLSpanElement>(null);
+
+  useFriction<HTMLDivElement>({
+    from: {
+      opacity: 0,
+    },
+    to: {
+      opacity: 1,
+    },
+    config: {
+      mu: number('mu', 0.1),
+      mass: number('mass', 30),
+      initialVelocity: number('velocity', 10),
+    },
+    onFrame: progress => {
+      if (progressRef.current) {
+        progressRef.current.innerHTML = `${progress.toFixed(2)}`;
+      }
+    },
+    onAnimationComplete: progress => {
+      if (progressRef.current) {
+        progressRef.current.innerHTML = `${progress.toFixed(2)}`;
+      }
+    },
+  });
+
+  return <span ref={progressRef} style={{ fontSize: '2rem' }} />;
 };

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -284,11 +284,6 @@ export const FrictionProgress: React.FC = () => {
         progressRef.current.innerHTML = `${progress.toFixed(2)}`;
       }
     },
-    onAnimationComplete: progress => {
-      if (progressRef.current) {
-        progressRef.current.innerHTML = `${progress.toFixed(2)}`;
-      }
-    },
   });
 
   return <span ref={progressRef} style={{ fontSize: '2rem' }} />;

--- a/stories/useGravity.stories.tsx
+++ b/stories/useGravity.stories.tsx
@@ -32,15 +32,11 @@ export const GravityControlled: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
     from: {
       opacity: toggle ? 0 : 1,
-      transform: toggle
-        ? 'scale(0) rotate(0deg) translate(-50%, -50%)'
-        : 'scale(1) rotate(180deg) translate(-50%, -50%)',
+      transform: toggle ? 'scale(0) rotate(0deg)' : 'scale(1) rotate(180deg)',
     },
     to: {
       opacity: toggle ? 1 : 0,
-      transform: toggle
-        ? 'scale(1) rotate(180deg) translate(-50%, -50%)'
-        : 'scale(0) rotate(0deg) translate(-50%, -50%)',
+      transform: toggle ? 'scale(1) rotate(180deg)' : 'scale(0) rotate(0deg)',
     },
     config: {
       moverMass: number('moverMass', 10000),
@@ -64,8 +60,8 @@ export const GravityControlled: React.FC = () => {
 
 export const GravityEventBased: React.FC = () => {
   const [props, controller] = useGravity<HTMLDivElement>({
-    from: { transform: 'translateX(0px) translate(-50%, -50%)' },
-    to: { transform: 'translateX(300px) translate(-50%, -50%)' },
+    from: { transform: 'translateX(0px)' },
+    to: { transform: 'translateX(300px)' },
     config: {
       moverMass: number('moverMass', 10000),
       attractorMass: number('attractorMass', 1000000000000),
@@ -86,11 +82,11 @@ export const GravityDelay: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
     from: {
       background: '#f25050',
-      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
+      transform: 'scale(1) rotate(0deg)',
     },
     to: {
       background: '#a04ad9',
-      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+      transform: 'scale(1.5) rotate(720deg)',
     },
     config: {
       moverMass: number('moverMass', 10000),
@@ -107,11 +103,11 @@ export const GravityInfinite: React.FC = () => {
   const [props] = useGravity<HTMLDivElement>({
     from: {
       background: '#f25050',
-      transform: 'scale(1) rotate(0deg) translate(-50%, -50%)',
+      transform: 'scale(1) rotate(0deg)',
     },
     to: {
       background: '#a04ad9',
-      transform: 'scale(1.5) rotate(720deg) translate(-50%, -50%)',
+      transform: 'scale(1.5) rotate(720deg)',
     },
     config: {
       moverMass: number('moverMass', 10000),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4243,10 +4243,10 @@ browserslist@^4.8.3:
     electron-to-chromium "^1.3.322"
     node-releases "^1.1.44"
 
-bs-platform@^7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.2.2.tgz#76fdc63e4889458ae3d257a0132107a792f2309c"
-  integrity sha512-PWcFfN+jCTtT/rMaHDhKh+W9RUTpaRunmSF9vbLYcrJbpgCNW6aFKAY33u0P3mLxwuhshN3b4FxqGUBPj6exZQ==
+bs-platform@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.3.2.tgz#301f5c9b4e8cf5713cb60ca22e145e56e793affe"
+  integrity sha512-seJL5g4anK9la4erv+B2o2sMHQCxDF6OCRl9en3hbaUos/S3JsusQ0sPp4ORsbx5eXfHLYBwPljwKXlgpXtsgQ==
 
 bser@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
This PR adds in two new ways of interacting with the `renature` API – `onFrame` and `onAnimationComplete`. This is one way I've thought of to support a few use cases in a single API:

- Allow users to execute their own logic in response to a new frame or animation completion.
- Hand users a `progress` value between 0 and 1 that represents the state of the physics tween.

The API looks like this:

```typescript
useFriction<HTMLDivElement>({
  ...,
  onFrame: progress => {
    /* Execute some logic in response to a frame update. */
  },
  onAnimationComplete: () => {
    /* Execute some logic now that the animation has finished. */
  },
});
```

`onFrame` currently receives `progress` as a value. This is the only API I've thought of where we can safely access `progress` as a `ref` value tracked in the animation functions themselves. We can't directly return `progress` from the hook itself, because we'd then need some way for the calling component to re-render in order for new values of `progress` to get picked up. And of course, with declarative animations like ours they'll restart if the component re-renders.

@NgoKnows take a look at the new example I added for accessing `progress` in `onFrame` and let me know if you think this would suit your needs! I'm not confident that this is necessarily the best API – just that it can solve certain problems by shifting more flexibility to the user. @littlemilkstudio would also appreciate your thoughts here!

![200524_progress](https://user-images.githubusercontent.com/19421190/82765397-dd056500-9dd3-11ea-9510-8bb8006e4d5b.gif)
