### PR TITLE
Move maxPosition calculations out of frame loop for friction and fluid resistance.

### DIFF
--- a/docs/src/screens/home/hero.js
+++ b/docs/src/screens/home/hero.js
@@ -33,12 +33,13 @@ const HeroBadge = styled.div`
   width: 20rem;
 
   @media ${p => p.theme.media.sm} {
-    width: 30rem;
+    width: 25rem;
     grid-column: 1 / span 5;
     justify-self: center;
   }
 
   @media ${p => p.theme.media.md} {
+    width: 30rem;
     grid-row: 1 / span 2;
   }
 `;

--- a/docs/src/screens/home/more-oss.js
+++ b/docs/src/screens/home/more-oss.js
@@ -47,8 +47,12 @@ const OSSCard = styled.div`
 `;
 
 const OSSBadge = styled.div`
-  flex: 0 0 15rem;
+  width: 15rem;
   height: 15rem;
+
+  @media ${p => p.theme.media.sm} {
+    flex: 0 0 15rem;
+  }
 `;
 
 const OSSCopyContainer = styled.div`

--- a/src/hooks/useFluidResistance.ts
+++ b/src/hooks/useFluidResistance.ts
@@ -32,13 +32,14 @@ export const useFluidResistance = <M extends HTMLElement | SVGElement = any>({
 
   const { controller } = React.useMemo(() => {
     const interpolators = getInterpolatorsForPairs({ from, to });
+    const maxPosition = getFluidPositionAtTerminalVelocity(config);
 
     return fluidResistance1D({
       config,
       onUpdate: ({ position }) => {
         interpolators.forEach(({ interpolator, property, values }) => {
           const value = interpolator({
-            range: [0, getFluidPositionAtTerminalVelocity(config)],
+            range: [0, maxPosition],
             domain: [values.from, values.to],
             value: position[1],
           });

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -28,19 +28,17 @@ export const useFriction = <M extends HTMLElement | SVGElement = any>({
 
   const { controller } = React.useMemo(() => {
     const interpolators = getInterpolatorsForPairs({ from, to });
+    const maxPosition = getMaxDistanceFriction({
+      mu: config.mu,
+      initialVelocity: config.initialVelocity,
+    });
 
     return friction1D({
       config,
       onUpdate: ({ position }) => {
         interpolators.forEach(({ interpolator, property, values }) => {
           const value = interpolator({
-            range: [
-              0,
-              getMaxDistanceFriction({
-                mu: config.mu,
-                initialVelocity: config.initialVelocity,
-              }),
-            ],
+            range: [0, maxPosition],
             domain: [values.from, values.to],
             value: position[0],
           });


### PR DESCRIPTION
A quick PR to do two things:

1. Move `maxPosition` calculations for `useFluidResistance` and `useFriction` out of the frame loop. There's no reason to calculate these values on every frame; we can derive them from the animation configuration. They only need to be derived once and then are good for the lifecycle of the animation or until the `config` options change.
2. I noticed our OSS badges weren't rendering correctly on mobile on Chrome, so I fixed that up real quick!