### PR TITLE
Fix transpilation of for of loops with Set caused by dangerousForOf in Buble config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.10.1",
-    "@babel/plugin-transform-for-of": "^7.10.4",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@babel/plugin-transform-object-assign": "^7.10.1",
     "@babel/preset-env": "^7.10.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.10.1",
+    "@babel/plugin-transform-for-of": "^7.10.4",
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@babel/plugin-transform-object-assign": "^7.10.1",
     "@babel/preset-env": "^7.10.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -108,8 +108,8 @@ const makePlugins = isProduction =>
     buble({
       transforms: {
         unicodeRegExp: false,
-        dangerousForOf: true,
         dangerousTaggedTemplateString: true,
+        forOf: false,
       },
       objectAssign: 'Object.assign',
       exclude: 'node_modules/**',
@@ -119,7 +119,11 @@ const makePlugins = isProduction =>
       extensions,
       include: ['src/**/*'],
       exclude: 'node_modules/**',
-      plugins: ['@babel/plugin-transform-object-assign', importAllPlugin],
+      plugins: [
+        '@babel/plugin-transform-object-assign',
+        '@babel/plugin-transform-for-of',
+        importAllPlugin,
+      ],
     }),
     isProduction &&
       replace({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,11 +119,7 @@ const makePlugins = isProduction =>
       extensions,
       include: ['src/**/*'],
       exclude: 'node_modules/**',
-      plugins: [
-        '@babel/plugin-transform-object-assign',
-        '@babel/plugin-transform-for-of',
-        importAllPlugin,
-      ],
+      plugins: ['@babel/plugin-transform-object-assign', importAllPlugin],
     }),
     isProduction &&
       replace({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,19 +1679,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-for-of@^7.10.4", "@babel/plugin-transform-for-of@^7.9.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
-  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-
 "@babel/plugin-transform-for-of@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz#248800e3a5e507b1f103d8b4ca998e77c63932bc"
   integrity sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-for-of@^7.9.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
+  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-function-name@^7.10.1":
   version "7.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,19 +1679,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
+"@babel/plugin-transform-for-of@^7.10.4", "@babel/plugin-transform-for-of@^7.9.0":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
+  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-transform-for-of@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz#248800e3a5e507b1f103d8b4ca998e77c63932bc"
   integrity sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-transform-for-of@^7.9.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
-  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-function-name@^7.10.1":
   version "7.10.1"
@@ -9077,7 +9077,7 @@ kind-of@^5.0.0:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.3"
+  version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9076,8 +9076,8 @@ kind-of@^5.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
-kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
+kind-of@^6.0.0, kind-of@^6.0.3:
+  version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 


### PR DESCRIPTION
This PR fixes a major 🐛 in v0.6.0. Previously, we had [`dangerousForOf`](http://buble.surge.sh/guide/#dangerous-transforms) enabled in our Buble transforms. `dangerousForOf` assumes all structures being iterated with `for...of` loop are array-like objects with a length property 😱 . This doesn't work for us because we iterate over a `Set` using `for...of`.

This PR adds in the necessary Babel transform to support IE11: https://babeljs.io/docs/en/babel-plugin-transform-for-of For now I'd like to keep IE11 support, but it is clear from the example that we end up adding a pretty hefty transpilation cost with this plugin. In a future release of `renature` (likely v1), we'll remove IE11 support entirely and strip this plugin. But for now, it makes sense to keep it in.