### PR TITLE
Fix #79. Use % rather than vw to fix resolution issues.

### DIFF
--- a/docs/src/screens/gallery/sample.js
+++ b/docs/src/screens/gallery/sample.js
@@ -47,7 +47,7 @@ const StyledContainer = styled.div`
   box-shadow: 1px 1px 20px rgba(20, 20, 20, 0.27);
   font-family: ${p => p.theme.fonts.code};
   overflow: auto;
-  width: 80vw;
+  width: 80%;
 
   > * {
     flex: 0 0 50%;


### PR DESCRIPTION
Fix #79 

This PR fixes an issue in our docs site caused by using `vw` units on a container that's inside of a parent with an explicit `max-width` set. This meant that on larger resolution devices our `80vw` would exceed our `max-width`, causing the overflow. This PR fixes this by using percentage units rather than `vw` to respect the containing parent's `max-width`.