### PR TITLE
Add support for recovering from interrupted animations.

### DIFF
--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -1,3 +1,5 @@
+import { CSSProperties } from 'react';
+
 import { vector as Vector } from '../core';
 import { Entity } from '../forces';
 
@@ -81,3 +83,5 @@ export interface AnimationGroup<C, E extends HTMLElement | SVGElement = any> {
   pause: () => void;
   stop: (element: StatefulAnimatingElement<C, E>) => void;
 }
+
+export type AnimationCache = Map<number, CSSProperties>;

--- a/src/hooks/useFluidResistanceGroup.ts
+++ b/src/hooks/useFluidResistanceGroup.ts
@@ -1,4 +1,11 @@
-import { createRef, useMemo, useLayoutEffect, useCallback } from 'react';
+import {
+  createRef,
+  useRef,
+  useMemo,
+  useLayoutEffect,
+  useCallback,
+  CSSProperties,
+} from 'react';
 
 import { CSSPairs, getInterpolatorsForPairs } from '../parsers';
 import {
@@ -9,6 +16,7 @@ import {
   Controller,
   VectorSetter,
   AnimatingElement,
+  AnimationCache,
 } from '../animation';
 import { getFluidPositionAtTerminalVelocity } from '../forces';
 
@@ -23,6 +31,9 @@ export const useFluidResistanceGroup = <
   n: number,
   fn: (index: number) => UseFluidResistanceArgs
 ): [{ ref: React.RefObject<E | null> }[], Controller] => {
+  // Set up a cache to store interpolated CSS state.
+  const cache = useRef<AnimationCache>(new Map());
+
   const { elements, start, stop, pause } = useMemo(() => {
     const animatingElements: AnimatingElement<
       FluidResistanceConfig,
@@ -65,6 +76,15 @@ export const useFluidResistanceGroup = <
             const progress = position[1] / maxPosition;
             props.onFrame(progress);
           }
+
+          // Update the global cache of derived animation values.
+          const currentCacheValue =
+            cache.current.get(i) ?? ({} as CSSProperties);
+
+          cache.current.set(i, {
+            ...currentCacheValue,
+            [property]: value,
+          });
         });
       };
 
@@ -76,6 +96,15 @@ export const useFluidResistanceGroup = <
         interpolators.forEach(({ property, values }) => {
           if (ref.current && ref.current.style[property as any] !== values.to) {
             ref.current.style[property as any] = values.to;
+
+            // Update the global cache of derived animation values.
+            const currentCacheValue =
+              cache.current.get(i) ?? ({} as CSSProperties);
+
+            cache.current.set(i, {
+              ...currentCacheValue,
+              [property]: values.to,
+            });
           }
         });
 

--- a/src/hooks/useFluidResistanceGroup.ts
+++ b/src/hooks/useFluidResistanceGroup.ts
@@ -48,7 +48,7 @@ export const useFluidResistanceGroup = <
       // Derive interpolator functions for the supplied CSS properties.
       const interpolators = getInterpolatorsForPairs(
         {
-          from: props.from,
+          from: cache.current.get(i) ?? props.from,
           to: props.to,
         },
         props.disableHardwareAcceleration

--- a/src/hooks/useGravityGroup.ts
+++ b/src/hooks/useGravityGroup.ts
@@ -1,4 +1,11 @@
-import { createRef, useMemo, useLayoutEffect, useCallback } from 'react';
+import {
+  createRef,
+  useRef,
+  useMemo,
+  useLayoutEffect,
+  useCallback,
+  CSSProperties,
+} from 'react';
 
 import { CSSPairs, getInterpolatorsForPairs } from '../parsers';
 import {
@@ -9,6 +16,7 @@ import {
   Controller,
   VectorSetter,
   AnimatingElement,
+  AnimationCache,
 } from '../animation';
 
 export type UseGravityArgs = CSSPairs &
@@ -20,6 +28,9 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
   n: number,
   fn: (index: number) => UseGravityArgs
 ): [{ ref: React.RefObject<E | null> }[], Controller] => {
+  // Set up a cache to store interpolated CSS state.
+  const cache = useRef<AnimationCache>(new Map());
+
   const { elements, start, stop, pause } = useMemo(() => {
     const animatingElements: AnimatingElement<
       GravityConfig,
@@ -62,6 +73,15 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
             const progress = position[0] / maxPosition;
             props.onFrame(progress);
           }
+
+          // Update the global cache of derived animation values.
+          const currentCacheValue =
+            cache.current.get(i) ?? ({} as CSSProperties);
+
+          cache.current.set(i, {
+            ...currentCacheValue,
+            [property]: value,
+          });
         });
       };
 
@@ -74,6 +94,15 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
           if (ref.current && ref.current.style[property as any] !== values.to) {
             ref.current.style[property as any] = values.to;
           }
+
+          // Update the global cache of derived animation values.
+          const currentCacheValue =
+            cache.current.get(i) ?? ({} as CSSProperties);
+
+          cache.current.set(i, {
+            ...currentCacheValue,
+            [property]: values.to,
+          });
         });
 
         if (props.onAnimationComplete) {

--- a/src/hooks/useGravityGroup.ts
+++ b/src/hooks/useGravityGroup.ts
@@ -45,7 +45,7 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
       // Derive interpolator functions for the supplied CSS properties.
       const interpolators = getInterpolatorsForPairs(
         {
-          from: props.from,
+          from: cache.current.get(i) ?? props.from,
           to: props.to,
         },
         props.disableHardwareAcceleration


### PR DESCRIPTION
Fix #89 

This PR addresses issues with interrupted animations. Previously in `renature`, if some value in the `from`, `to`, or `config` properties of a hook changed, the animation would restart from the beginning. You can see a GIF of this in the linked issue. This was problematic for reactive animations, i.e. toggle or hover effects. In these cases, you want your animation to resume running from the animating element's last known set of animated styles rather than restarting from the beginning.

To fix this, I'm introducing the notion of an animated values cache. In this setup, we cache the interpolated animated styles of the simulated mover on each frame. This means that, if an animation gets interrupted, we start the new animation from the cached set of styles. An example – say we're moving between `opacity: 1` and `opacity: 0`. An animation gets interrupted and now it's instructed to animate instead to `opacity: 0.25`. At this moment, its current interpolated value (sat, `opacity: 0.5`) is cached. On the next re-render, rather than restarting the animation from `opacity: 1`, `renature` will start it at `opacity: 0.5`. This allows for animations that feel smooth and reactive to user input.

![200913_renature_interrupted_animations](https://user-images.githubusercontent.com/19421190/93031233-0b56bc80-f5de-11ea-8157-b39f5c7e9286.gif)

I'd be curious to get feedback on this approach. I like that it can help reactive animations feel a lot smoother, and it opens the way to address the `controller.set` API discussed in #86. The downside is that motion values themselves (`velocity` in particular) are not preserved across updates. This is a worthwhile tradeoff IMO. If we preserved `velocity`, there's a chance enough updates would result in atypical velocity values that would send a mover past it's possible range (which is calculated ahead of the animation running based on its configuration). This would result in animations that never reach their `to` state and then jump to it when `onComplete` is called – no good.

I am seeking active feedback here for any clever ideas! If the approach looks good I'll replicate to other hooks in this PR before merging.
