### PR TITLE
test(fluidResistance): add unit tests for fluidResistanceGroup function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,10 @@ module.exports = {
     'react/prop-types': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    'jest/no-disabled-tests': 'warn',
+    'jest/no-focused-tests': 'error',
+    'jest/no-identical-title': 'error',
+    'jest/prefer-to-have-length': 'warn',
+    'jest/valid-expect': 'error',
   },
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ branches:
 language: node_js
 
 node_js:
-  - 10
   - 12
+  - 14
 
 before_install:
   # Add `aws` CLI tool.
@@ -27,25 +27,25 @@ jobs:
         - yarn build:res
         - yarn test
     - <<: *buildReTest
-      node_js: 12
+      node_js: 14
     - &checkTs
       stage: Check TypeScript
       script:
         - yarn check:ts
     - <<: *checkTs
-      node_js: 12
+      node_js: 14
     - &lint
       stage: Lint
       script:
         - yarn lint
     - <<: *lint
-      node_js: 12
+      node_js: 14
     - &build
       stage: Build
       script:
         - yarn build
     - <<: *build
-      node_js: 12
+      node_js: 14
     - stage: documentation
       node_js: 12
       script:

--- a/__tests__/animation/fluidResistance.spec.ts
+++ b/__tests__/animation/fluidResistance.spec.ts
@@ -36,7 +36,7 @@ describe('fluidResistance', () => {
     expect(elements).toHaveLength(3);
   });
 
-  it('fluidResistance should return a start function that starts the frameloop', () => {
+  it('should return a start function that starts the frameloop', () => {
     const requestAnimationFrameSpy = jest.spyOn(
       window,
       'requestAnimationFrame'
@@ -70,9 +70,11 @@ describe('fluidResistance', () => {
 
     let prevState = elements.map(({ state }) => state.mover);
 
-    // Animate 10 frames, verifying that the physics state has changed on each frame.
-    // Discard the first frame, which initializes animation state but doesn't begin
-    // applying the force.
+    /**
+     * Animate 10 frames, verifying that the physics state has changed on each frame.
+     * Discard the first frame, which initializes animation state but doesn't begin
+     * applying the force.
+     */
     for (let i = 0; i < 10; i++) {
       mockRAF.step({ count: i === 0 ? 2 : 1 });
 
@@ -107,9 +109,11 @@ describe('fluidResistance', () => {
 
     start();
 
-    // Animate 440 frames, equivalent to 5.5 seconds.
-    // With the baseline physics configuration, we should reach the reversal state
-    // at approximately this time.
+    /**
+     * Animate 440 frames, equivalent to 5.5 seconds.
+     * With the baseline physics configuration, we should
+     * reach the reversal state at approximately this time.
+     */
     mockRAF.step({ count: 440 });
 
     expect(
@@ -131,9 +135,11 @@ describe('fluidResistance', () => {
 
     start();
 
-    // Animate 440 frames, equivalent to 5.5 seconds.
-    // With the baseline physics configuration, we should reach the reversal state
-    // at approximately this time.
+    /**
+     * Animate 440 frames, equivalent to 5.5 seconds.
+     * With the baseline physics configuration, we should
+     * reach the reversal state at approximately this time.
+     */
     mockRAF.step({ count: 440 });
 
     expect(
@@ -148,7 +154,7 @@ describe('fluidResistance', () => {
     ).toBe(true);
   });
 
-  it('should apply a settling effect to the animation if specified', () => {
+  it('should apply a settling effect to the animation if specified in the physics config', () => {
     const mockRAF = new MockRAF();
 
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRAF.rAF);
@@ -175,9 +181,11 @@ describe('fluidResistance', () => {
       true
     );
 
-    // Animate another frame, enough to have triggered the settling effect.
-    // At this point, the velocity vector should be negative, but the play state should
-    // still be forward.
+    /**
+     * Animate another frame, enough to have triggered the settling effect.
+     * At this point, the velocity vector should be negative, but the play
+     * state should still be forward.
+     */
     mockRAF.step({ count: 1 });
     expect(elements.every(({ state }) => state.mover.velocity[1] < 0)).toBe(
       true

--- a/__tests__/animation/fluidResistance.spec.ts
+++ b/__tests__/animation/fluidResistance.spec.ts
@@ -1,0 +1,189 @@
+import { createRef } from 'react';
+
+import { MockRAF } from '../test-utils/mockRAF';
+import {
+  AnimatingElement,
+  FluidResistanceConfig,
+  fluidResistanceGroup,
+  PlayState,
+} from '../../src/animation';
+
+describe('fluidResistance', () => {
+  const baseElement: AnimatingElement<FluidResistanceConfig, HTMLElement> = {
+    ref: createRef(),
+    config: {
+      mass: 25,
+      rho: 10,
+      area: 20,
+      cDrag: 0.1,
+    },
+    onUpdate: jest.fn(),
+    onComplete: jest.fn(),
+  };
+
+  it('should create a group of animating elements and return functions for starting, stopping, and pausing the animation group', () => {
+    const mockElements: AnimatingElement<
+      FluidResistanceConfig,
+      HTMLElement
+    >[] = new Array(3).fill(baseElement);
+
+    const { start, stop, pause, elements } = fluidResistanceGroup(mockElements);
+
+    expect(typeof start).toBe('function');
+    expect(typeof stop).toBe('function');
+    expect(typeof pause).toBe('function');
+
+    expect(elements).toHaveLength(3);
+  });
+
+  it('fluidResistance should return a start function that starts the frameloop', () => {
+    const requestAnimationFrameSpy = jest.spyOn(
+      window,
+      'requestAnimationFrame'
+    );
+
+    const mockElements: AnimatingElement<
+      FluidResistanceConfig,
+      HTMLElement
+    >[] = new Array(3).fill(baseElement);
+
+    const { start } = fluidResistanceGroup(mockElements);
+
+    start();
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalled();
+  });
+
+  it('should apply the fluid resistance force on each step', () => {
+    const mockRAF = new MockRAF();
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRAF.rAF);
+
+    const mockElements: AnimatingElement<
+      FluidResistanceConfig,
+      HTMLElement
+    >[] = new Array(3).fill(baseElement);
+
+    const { start, elements } = fluidResistanceGroup(mockElements);
+
+    start();
+
+    let prevState = elements.map(({ state }) => state.mover);
+
+    // Animate 10 frames, verifying that the physics state has changed on each frame.
+    // Discard the first frame, which initializes animation state but doesn't begin
+    // applying the force.
+    for (let i = 0; i < 10; i++) {
+      mockRAF.step({ count: i === 0 ? 2 : 1 });
+
+      elements.forEach((element, i) => {
+        expect(prevState[i].acceleration[1]).not.toEqual(
+          element.state.mover.acceleration[1]
+        );
+        expect(prevState[i].velocity[1]).not.toEqual(
+          element.state.mover.velocity[1]
+        );
+        expect(prevState[i].position[1]).not.toEqual(
+          element.state.mover.position[1]
+        );
+      });
+
+      // Set the prevState to the current state at the end of each iteration.
+      prevState = elements.map(({ state }) => state.mover);
+    }
+  });
+
+  it('should check and modify the play state of an infinite animation', () => {
+    const mockRAF = new MockRAF();
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRAF.rAF);
+
+    const mockElements: AnimatingElement<
+      FluidResistanceConfig,
+      HTMLElement
+    >[] = new Array(3).fill({ ...baseElement, infinite: true });
+
+    const { start, elements } = fluidResistanceGroup(mockElements);
+
+    start();
+
+    // Animate 440 frames, equivalent to 5.5 seconds.
+    // With the baseline physics configuration, we should reach the reversal state
+    // at approximately this time.
+    mockRAF.step({ count: 440 });
+
+    expect(
+      elements.every(({ state }) => state.playState === PlayState.Reverse)
+    ).toBe(true);
+  });
+
+  it('should continually reverse infinite animations when they reach their ending physics conditions', () => {
+    const mockRAF = new MockRAF();
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRAF.rAF);
+
+    const mockElements: AnimatingElement<
+      FluidResistanceConfig,
+      HTMLElement
+    >[] = new Array(3).fill({ ...baseElement, infinite: true });
+
+    const { start, elements } = fluidResistanceGroup(mockElements);
+
+    start();
+
+    // Animate 440 frames, equivalent to 5.5 seconds.
+    // With the baseline physics configuration, we should reach the reversal state
+    // at approximately this time.
+    mockRAF.step({ count: 440 });
+
+    expect(
+      elements.every(({ state }) => state.playState === PlayState.Reverse)
+    ).toBe(true);
+
+    // Animate another 440 frames and verify that we've switched to the Forward play state.
+    mockRAF.step({ count: 440 });
+
+    expect(
+      elements.every(({ state }) => state.playState === PlayState.Forward)
+    ).toBe(true);
+  });
+
+  it('should apply a settling effect to the animation if specified', () => {
+    const mockRAF = new MockRAF();
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRAF.rAF);
+
+    const mockElements: AnimatingElement<
+      FluidResistanceConfig,
+      HTMLElement
+    >[] = new Array(3).fill({
+      ...baseElement,
+      config: { ...baseElement.config, infinite: true, settle: true },
+    });
+
+    const { start, elements } = fluidResistanceGroup(mockElements);
+
+    start();
+
+    // Animate to the last frame before crossing the maxDistance threshold.
+    mockRAF.step({ count: 511 });
+
+    expect(
+      elements.every(({ state }) => state.playState === PlayState.Forward)
+    ).toBe(true);
+    expect(elements.every(({ state }) => state.mover.velocity[1] > 0)).toBe(
+      true
+    );
+
+    // Animate another frame, enough to have triggered the settling effect.
+    // At this point, the velocity vector should be negative, but the play state should
+    // still be forward.
+    mockRAF.step({ count: 1 });
+    expect(elements.every(({ state }) => state.mover.velocity[1] < 0)).toBe(
+      true
+    );
+    expect(
+      elements.every(({ state }) => state.playState === PlayState.Forward)
+    ).toBe(true);
+  });
+});

--- a/__tests__/animation/group.spec.ts
+++ b/__tests__/animation/group.spec.ts
@@ -66,7 +66,7 @@ describe('group', () => {
     expect(elements.every(({ state }) => state === baseState)).toBe(true);
   });
 
-  it('should set modify the delayed state of an element after its delay timeout has elapsed', () => {
+  it('should modify the delayed state of an element after its delay timeout has elapsed', () => {
     jest.useFakeTimers();
 
     const mockElements: AnimatingElement<

--- a/__tests__/parsers/pairs.spec.ts
+++ b/__tests__/parsers/pairs.spec.ts
@@ -1,187 +1,185 @@
 import { getInterpolatorsForPairs } from '../../src/parsers';
 
-describe('pairs', () => {
-  describe('getInterpolatorsForPairs', () => {
-    it('should infer a from / to pair of type number and return a numeric interpolator', () => {
-      const pairs = {
-        from: { opacity: 0 },
-        to: { opacity: 1 },
-      };
+describe('getInterpolatorsForPairs', () => {
+  it('should infer a from / to pair of type number and return a numeric interpolator', () => {
+    const pairs = {
+      from: { opacity: 0 },
+      to: { opacity: 1 },
+    };
 
-      const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+    const [{ interpolator }] = getInterpolatorsForPairs(pairs);
 
-      const result = interpolator({
-        range: [100, 400],
-        domain: [pairs.from.opacity, pairs.to.opacity],
-        value: 175,
-      });
-      expect(result).toEqual(0.25);
+    const result = interpolator({
+      range: [100, 400],
+      domain: [pairs.from.opacity, pairs.to.opacity],
+      value: 175,
+    });
+    expect(result).toEqual(0.25);
+  });
+
+  it('should infer a from / to pair of type string that matches a color and return a color interpolator', () => {
+    const pairs = {
+      from: { background: '#c86432bf' }, // rgba(200, 100, 50, 0.75)
+      to: { background: '#64c84b' }, // rgba(100, 200, 75, 1)
+    };
+    const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+
+    const result = interpolator({
+      range: [100, 400],
+      domain: [
+        { r: 200, g: 100, b: 50, a: 0.75 },
+        { r: 100, g: 200, b: 75, a: 1 },
+      ],
+      value: 175,
+    });
+    expect(result).toEqual('rgba(175, 125, 56, 0.8125)');
+  });
+
+  it('should infer a from / to pair of type string that matches a united number and return a unit interpolator', () => {
+    const pairs = {
+      from: { left: '10px' },
+      to: { left: '200px' },
+    };
+
+    const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+
+    const result = interpolator({
+      range: [100, 400],
+      domain: [pairs.from.left, pairs.to.left],
+      value: 175,
+    });
+    expect(result).toEqual('57.5px');
+  });
+
+  it('should infer a from / to pair of type string that matches a transform and return a transform interpolator', () => {
+    const pairs = {
+      from: { transform: 'rotate(20rad)' },
+      to: { transform: 'rotate(50rad)' },
+      disableHardwareAcceleration: true,
+    };
+    const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+
+    const result = interpolator({
+      range: [100, 400],
+      domain: [pairs.from.transform, pairs.to.transform],
+      value: 175,
+    });
+    expect(result).toEqual('rotate(27.5rad)');
+  });
+
+  it('should infer a from / to pair of type string that matches a box-shadow and return a box-shadow interpolator', () => {
+    const pairs = {
+      from: { boxShadow: '10px 10px 10px rgba(0, 0, 0, 1)' },
+      to: { boxShadow: '30px 20px rgba(100, 200, 160, 0)' },
+    };
+    const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+
+    const result = interpolator({
+      range: [100, 400],
+      domain: [pairs.from.boxShadow, pairs.to.boxShadow],
+      value: 175,
+    });
+    expect(result).toEqual('15px 12.5px 7.5px 0px rgba(25, 50, 40, 0.75)');
+  });
+
+  it('should throw an error if attempting to animate two different properties', () => {
+    const pairs = {
+      from: { left: '10px' },
+      to: { right: '200px' },
+    };
+
+    expect(() => getInterpolatorsForPairs(pairs)).toThrowError(
+      'Could not find a to value for from property: left.'
+    );
+  });
+
+  it('should throw an error if attempting to animate values of different types', () => {
+    const pairs = {
+      from: { left: '10px' },
+      to: { left: 0 },
+    };
+
+    expect(() => getInterpolatorsForPairs(pairs)).toThrowError(
+      'from and to values have mismatching types. from type: string does not match to type: number.'
+    );
+  });
+
+  it('should throw an error if it cannot parse the passed in values', () => {
+    const pairs = {
+      from: { transform: 'try to parse this' },
+      to: { transform: 'if you can' },
+    };
+
+    expect(() => getInterpolatorsForPairs(pairs)).toThrowError(
+      "Unable to parse configuration from: 'try to parse this' or to: 'if you can'"
+    );
+  });
+
+  it('should append translateZ(0) to a transform animation', () => {
+    const pairs = {
+      from: { transform: 'rotate(20rad)' },
+      to: { transform: 'rotate(50rad)' },
+      disableHardwareAcceleration: true,
+    };
+    const [{ interpolator, values }] = getInterpolatorsForPairs(pairs);
+
+    expect(values).toEqual({
+      from: 'rotate(20rad) translateZ(0)',
+      to: 'rotate(50rad) translateZ(0)',
     });
 
-    it('should infer a from / to pair of type string that matches a color and return a color interpolator', () => {
-      const pairs = {
-        from: { background: '#c86432bf' }, // rgba(200, 100, 50, 0.75)
-        to: { background: '#64c84b' }, // rgba(100, 200, 75, 1)
-      };
-      const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+    const result = interpolator({
+      range: [100, 400],
+      domain: [values.from, values.to],
+      value: 175,
+    });
+    expect(result).toEqual('rotate(27.5rad) translateZ(0)');
+  });
 
-      const result = interpolator({
-        range: [100, 400],
-        domain: [
-          { r: 200, g: 100, b: 50, a: 0.75 },
-          { r: 100, g: 200, b: 75, a: 1 },
-        ],
-        value: 175,
-      });
-      expect(result).toEqual('rgba(175, 125, 56, 0.8125)');
+  it('should not append translateZ(0) to a transform animation if translateZ is already being animated', () => {
+    const pairs = {
+      from: { transform: 'rotate(20rad) translateZ(0rem)' },
+      to: { transform: 'rotate(50rad) translateZ(10rem)' },
+      disableHardwareAcceleration: true,
+    };
+    const [{ interpolator, values }] = getInterpolatorsForPairs(pairs);
+
+    expect(values).toEqual({
+      from: 'rotate(20rad) translateZ(0rem)',
+      to: 'rotate(50rad) translateZ(10rem)',
     });
 
-    it('should infer a from / to pair of type string that matches a united number and return a unit interpolator', () => {
-      const pairs = {
-        from: { left: '10px' },
-        to: { left: '200px' },
-      };
+    const result = interpolator({
+      range: [100, 400],
+      domain: [values.from, values.to],
+      value: 175,
+    });
+    expect(result).toEqual('rotate(27.5rad) translateZ(2.5rem)');
+  });
 
-      const [{ interpolator }] = getInterpolatorsForPairs(pairs);
+  it('should get a set of interpolators for many from / to pairs', () => {
+    const pairs = {
+      from: { opacity: 0, transform: 'translateX(10px)' },
+      to: { opacity: 1, transform: 'translateX(20px)' },
+    };
+    const [
+      { interpolator: opacityInterpolator },
+      { interpolator: transformInterpolator },
+    ] = getInterpolatorsForPairs(pairs);
 
-      const result = interpolator({
-        range: [100, 400],
-        domain: [pairs.from.left, pairs.to.left],
-        value: 175,
-      });
-      expect(result).toEqual('57.5px');
+    const opacityResult = opacityInterpolator({
+      range: [100, 400],
+      domain: [pairs.from.opacity, pairs.to.opacity],
+      value: 175,
+    });
+    expect(opacityResult).toEqual(0.25);
+
+    const transformResult = transformInterpolator({
+      range: [100, 400],
+      domain: [pairs.from.transform, pairs.to.transform],
+      value: 175,
     });
 
-    it('should infer a from / to pair of type string that matches a transform and return a transform interpolator', () => {
-      const pairs = {
-        from: { transform: 'rotate(20rad)' },
-        to: { transform: 'rotate(50rad)' },
-        disableHardwareAcceleration: true,
-      };
-      const [{ interpolator }] = getInterpolatorsForPairs(pairs);
-
-      const result = interpolator({
-        range: [100, 400],
-        domain: [pairs.from.transform, pairs.to.transform],
-        value: 175,
-      });
-      expect(result).toEqual('rotate(27.5rad)');
-    });
-
-    it('should infer a from / to pair of type string that matches a box-shadow and return a box-shadow interpolator', () => {
-      const pairs = {
-        from: { boxShadow: '10px 10px 10px rgba(0, 0, 0, 1)' },
-        to: { boxShadow: '30px 20px rgba(100, 200, 160, 0)' },
-      };
-      const [{ interpolator }] = getInterpolatorsForPairs(pairs);
-
-      const result = interpolator({
-        range: [100, 400],
-        domain: [pairs.from.boxShadow, pairs.to.boxShadow],
-        value: 175,
-      });
-      expect(result).toEqual('15px 12.5px 7.5px 0px rgba(25, 50, 40, 0.75)');
-    });
-
-    it('should throw an error if attempting to animate two different properties', () => {
-      const pairs = {
-        from: { left: '10px' },
-        to: { right: '200px' },
-      };
-
-      expect(() => getInterpolatorsForPairs(pairs)).toThrowError(
-        'Could not find a to value for from property: left.'
-      );
-    });
-
-    it('should throw an error if attempting to animate values of different types', () => {
-      const pairs = {
-        from: { left: '10px' },
-        to: { left: 0 },
-      };
-
-      expect(() => getInterpolatorsForPairs(pairs)).toThrowError(
-        'from and to values have mismatching types. from type: string does not match to type: number.'
-      );
-    });
-
-    it('should throw an error if it cannot parse the passed in values', () => {
-      const pairs = {
-        from: { transform: 'try to parse this' },
-        to: { transform: 'if you can' },
-      };
-
-      expect(() => getInterpolatorsForPairs(pairs)).toThrowError(
-        "Unable to parse configuration from: 'try to parse this' or to: 'if you can'"
-      );
-    });
-
-    it('should append translateZ(0) to a transform animation', () => {
-      const pairs = {
-        from: { transform: 'rotate(20rad)' },
-        to: { transform: 'rotate(50rad)' },
-        disableHardwareAcceleration: true,
-      };
-      const [{ interpolator, values }] = getInterpolatorsForPairs(pairs);
-
-      expect(values).toEqual({
-        from: 'rotate(20rad) translateZ(0)',
-        to: 'rotate(50rad) translateZ(0)',
-      });
-
-      const result = interpolator({
-        range: [100, 400],
-        domain: [values.from, values.to],
-        value: 175,
-      });
-      expect(result).toEqual('rotate(27.5rad) translateZ(0)');
-    });
-
-    it('should not append translateZ(0) to a transform animation if translateZ is already being animated', () => {
-      const pairs = {
-        from: { transform: 'rotate(20rad) translateZ(0rem)' },
-        to: { transform: 'rotate(50rad) translateZ(10rem)' },
-        disableHardwareAcceleration: true,
-      };
-      const [{ interpolator, values }] = getInterpolatorsForPairs(pairs);
-
-      expect(values).toEqual({
-        from: 'rotate(20rad) translateZ(0rem)',
-        to: 'rotate(50rad) translateZ(10rem)',
-      });
-
-      const result = interpolator({
-        range: [100, 400],
-        domain: [values.from, values.to],
-        value: 175,
-      });
-      expect(result).toEqual('rotate(27.5rad) translateZ(2.5rem)');
-    });
-
-    it('should get a set of interpolators for many from / to pairs', () => {
-      const pairs = {
-        from: { opacity: 0, transform: 'translateX(10px)' },
-        to: { opacity: 1, transform: 'translateX(20px)' },
-      };
-      const [
-        { interpolator: opacityInterpolator },
-        { interpolator: transformInterpolator },
-      ] = getInterpolatorsForPairs(pairs);
-
-      const opacityResult = opacityInterpolator({
-        range: [100, 400],
-        domain: [pairs.from.opacity, pairs.to.opacity],
-        value: 175,
-      });
-      expect(opacityResult).toEqual(0.25);
-
-      const transformResult = transformInterpolator({
-        range: [100, 400],
-        domain: [pairs.from.transform, pairs.to.transform],
-        value: 175,
-      });
-
-      expect(transformResult).toEqual('translateX(12.5px)');
-    });
+    expect(transformResult).toEqual('translateX(12.5px)');
   });
 });

--- a/__tests__/test-utils/mockRAF.ts
+++ b/__tests__/test-utils/mockRAF.ts
@@ -1,0 +1,53 @@
+type RAFCallback = (timestamp: DOMHighResTimeStamp) => void;
+
+export class MockRAF {
+  #now: number;
+  #callbacks: Record<number, RAFCallback>;
+  #callbacksLength: number;
+
+  constructor() {
+    this.#now = 0;
+    this.#callbacks = {};
+    this.#callbacksLength = 0;
+  }
+
+  get now(): number {
+    return this.#now;
+  }
+
+  rAF = (cb: RAFCallback): number => {
+    this.#callbacksLength += 1;
+    this.#callbacks[this.#callbacksLength] = cb;
+
+    return this.#callbacksLength;
+  };
+
+  cancel = (id: number): void => {
+    delete this.#callbacks[id];
+  };
+
+  step = (opts: { time?: number; count?: number } = {}): void => {
+    const options = {
+      time: 1000 / 60,
+      count: 1,
+      ...opts,
+    };
+
+    let prevCallbacks: Record<
+      number,
+      (timestamp: DOMHighResTimeStamp) => void
+    > = {};
+
+    for (let i = 0; i < options.count; i++) {
+      prevCallbacks = this.#callbacks;
+      this.#callbacks = {};
+
+      this.#now += options.time;
+
+      Object.keys(prevCallbacks).forEach((id) => {
+        const callback = prevCallbacks[parseInt(id, 10)];
+        callback(this.#now);
+      });
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
       "node_modules/(?!(@glennsl/bs-jest|bs-platform)/)"
     ],
     "coveragePathIgnorePatterns": [
-      ".gen.tsx"
+      ".gen.tsx",
+      "/__tests__/test-utils"
     ]
   },
   "prettier": {

--- a/src/hooks/useFluidResistanceGroup.ts
+++ b/src/hooks/useFluidResistanceGroup.ts
@@ -77,7 +77,7 @@ export const useFluidResistanceGroup = <
             props.onFrame(progress);
           }
 
-          // Update the global cache of derived animation values.
+          // Update the cache of derived animation values.
           const currentCacheValue =
             cache.current.get(i) ?? ({} as CSSProperties);
 
@@ -97,7 +97,7 @@ export const useFluidResistanceGroup = <
           if (ref.current && ref.current.style[property as any] !== values.to) {
             ref.current.style[property as any] = values.to;
 
-            // Update the global cache of derived animation values.
+            // Update the cache of derived animation values.
             const currentCacheValue =
               cache.current.get(i) ?? ({} as CSSProperties);
 

--- a/src/hooks/useFrictionGroup.ts
+++ b/src/hooks/useFrictionGroup.ts
@@ -76,7 +76,7 @@ export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
             props.onFrame(progress);
           }
 
-          // Update the global cache of derived animation values.
+          // Update the cache of derived animation values.
           const currentCacheValue =
             cache.current.get(i) ?? ({} as CSSProperties);
 
@@ -96,7 +96,7 @@ export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
           if (ref.current && ref.current.style[property as any] !== values.to) {
             ref.current.style[property as any] = values.to;
 
-            // Update the global cache of derived animation values.
+            // Update the cache of derived animation values.
             const currentCacheValue =
               cache.current.get(i) ?? ({} as CSSProperties);
 

--- a/src/hooks/useGravityGroup.ts
+++ b/src/hooks/useGravityGroup.ts
@@ -74,7 +74,7 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
             props.onFrame(progress);
           }
 
-          // Update the global cache of derived animation values.
+          // Update the cache of derived animation values.
           const currentCacheValue =
             cache.current.get(i) ?? ({} as CSSProperties);
 
@@ -95,7 +95,7 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
             ref.current.style[property as any] = values.to;
           }
 
-          // Update the global cache of derived animation values.
+          // Update the cache of derived animation values.
           const currentCacheValue =
             cache.current.get(i) ?? ({} as CSSProperties);
 


### PR DESCRIPTION
This PR does a few cool things, the first major one being the addition of unit tests for the `fluidResistanceGroup` function. This function hands off a lot of logic to the already tested `group` and `update` functions. However, unit testing those functions was easier because we could modify their calling conditions to force particular scenarios that happen during the course of the frameloop running. In testing this function, we need a way to advance the frameloop ourselves.

Enter in the `MockRAF` class, which you'll find in this PR in the `test-utils` folder. `MockRAF` gives us a nice mock for `requestAnimationFrame`, exposing a `step` method to allow us to advance `n` steps in the frameloop and assert on the state of our physics animation. My implementation is a `class`-based, TypeScript compatible version of [this implementation](https://github.com/FormidableLabs/mock-raf), which takes cue from `react-motion`. This should allow us to add very similar tests for `friction` and `gravity` with relatively little trouble!

This PR also modifies some of the logic in the `getInterpolatorsForPairs` function. The major changes:

- We type incoming `from` and `to` values as `unknown` and do proper runtime type checks to discern their types. This is _much better_ than using `any`, because we get full type inference through our branching without needing any type casting.
- We `throw` on invariants. Some of our invariants:
  - `from` specifies a CSS property that `to` doesn't specify. In this case, the user would be missing a `to` configuration for a `from` property, which we can't animate.
  - `from` and `to` have mismatching types for a particular CSS property.
  - Unparseable values — we'd like to actually more about these cases where our parsing fails, especially if the CSS is valid.

I revised our tests in `pairs` to _only_ test `getInterpolatorsForPairs` (our public API for this module) and ensure we trigger code paths via calling this function rather than exporting its lower-level internals.