### PR TITLE
fix: clear animation cache on animation end

### DIFF
--- a/src/hooks/useFluidResistanceGroup.ts
+++ b/src/hooks/useFluidResistanceGroup.ts
@@ -97,14 +97,15 @@ export const useFluidResistanceGroup = <
           if (ref.current && ref.current.style[property as any] !== values.to) {
             ref.current.style[property as any] = values.to;
 
-            // Update the cache of derived animation values.
-            const currentCacheValue =
+            // Clear the cache for this particular property.
+            const { [property]: _animatedProperty, ...currentCacheValue } =
               cache.current.get(i) ?? ({} as CSSProperties);
 
-            cache.current.set(i, {
-              ...currentCacheValue,
-              [property]: values.to,
-            });
+            if (Object.keys(currentCacheValue).length > 0) {
+              cache.current.set(i, currentCacheValue);
+            } else {
+              cache.current.delete(i);
+            }
           }
         });
 

--- a/src/hooks/useFrictionGroup.ts
+++ b/src/hooks/useFrictionGroup.ts
@@ -100,14 +100,15 @@ export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
             ) {
               ref.current.style[property as any] = values.to;
 
-              // Update the cache of derived animation values.
-              const currentCacheValue =
+              // Clear the cache for this particular property.
+              const { [property]: _animatedProperty, ...currentCacheValue } =
                 cache.current.get(i) ?? ({} as CSSProperties);
 
-              cache.current.set(i, {
-                ...currentCacheValue,
-                [property]: values.to,
-              });
+              if (Object.keys(currentCacheValue).length > 0) {
+                cache.current.set(i, currentCacheValue);
+              } else {
+                cache.current.delete(i);
+              }
             }
           });
 

--- a/src/hooks/useGravity2D.ts
+++ b/src/hooks/useGravity2D.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { RefObject, useRef, useMemo, useLayoutEffect } from 'react';
 
 import {
   Gravity2DParams,
@@ -17,7 +17,7 @@ type UseGravity2DArgs = {
   disableHardwareAcceleration?: boolean;
 };
 
-export const useGravity2D = <M extends HTMLElement | SVGElement = any>({
+export const useGravity2D = <E extends HTMLElement | SVGElement = any>({
   config = gravity2DDefaultConfig,
   pause = false,
   delay,
@@ -25,7 +25,7 @@ export const useGravity2D = <M extends HTMLElement | SVGElement = any>({
   onAnimationComplete,
   disableHardwareAcceleration = false,
 }: UseGravity2DArgs): [
-  { ref: React.MutableRefObject<M | null> },
+  { ref: RefObject<E> },
   Controller & Gravity2DController
 ] => {
   /**
@@ -34,9 +34,9 @@ export const useGravity2D = <M extends HTMLElement | SVGElement = any>({
    * is what allows us to directly update the style property
    * without triggering rerenders.
    */
-  const moverRef = React.useRef<M | null>(null);
+  const moverRef = useRef<E>(null);
 
-  const { controller } = React.useMemo(
+  const { controller } = useMemo(
     () =>
       gravity2D({
         config,
@@ -59,7 +59,7 @@ export const useGravity2D = <M extends HTMLElement | SVGElement = any>({
     [config, onFrame, onAnimationComplete, disableHardwareAcceleration]
   );
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (!pause && !delay) {
       controller.start();
     }

--- a/src/hooks/useGravityGroup.ts
+++ b/src/hooks/useGravityGroup.ts
@@ -97,14 +97,15 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
               ref.current.style[property as any] = values.to;
             }
 
-            // Update the cache of derived animation values.
-            const currentCacheValue =
+            // Clear the cache for this particular property.
+            const { [property]: _animatedProperty, ...currentCacheValue } =
               cache.current.get(i) ?? ({} as CSSProperties);
 
-            cache.current.set(i, {
-              ...currentCacheValue,
-              [property]: values.to,
-            });
+            if (Object.keys(currentCacheValue).length > 0) {
+              cache.current.set(i, currentCacheValue);
+            } else {
+              cache.current.delete(i);
+            }
           });
 
           if (props.onAnimationComplete) {


### PR DESCRIPTION
Fix #101 

This PR adds a solution for clearing the animation cache of a `renature` hook when an animation has completed. Previously, `renature` hooks _never_ cleared their animation cache after running. This meant that animations couldn't be restarted from the beginning unless the component calling the hook (`useFriction`, `useGravity`, etc.) was fully unmounted. This was a product of us caching animation state values to support "interrupted animations", where an animation's `to` value changed mid-execution.

To fix this, at least in the short term, we clear out the animation cache when an animation completes. This is by no means a bulletproof fix, but it at least ensures animations can be re-run without needing to fully unmount. Here's the current working model:

- Animation starts with its configured `from` / `to` values.
- An update comes in that changes animation configuration. The animation begins moving towards its `to` value with the updated physics config, and looks at its _current style_ (stored in the animation cache) to determine the `from` value to use for the physics tween.
- The animation completes and the animation cache is cleared.
- The component is re-rendered and the animation starts from its originally specified `from` value.

Here's a look at Storybook, where we updated physics config values and we can see the animation re-running immediately.

![20210104_animation_cache](https://user-images.githubusercontent.com/19421190/103556748-74a15a80-4e6f-11eb-946a-4860ab47643f.gif)

I'm beginning to think we need to research a new approach to this problem. The animation cache is a tricky thing to maintain, especially given the fact that [elements already store information about their currently styling for a property](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle). I'd love to hear thoughts on using native DOM APIs like `window.getComputedStyle` and `style.getPropertyValue` to retrieve this information. Looking at some prior art, I know that [`d3` uses these APIs to compute tweens](https://github.com/d3/d3-transition#transition_style).