### PR TITLE
fix: support interpolating transforms specified in any order

### DIFF
--- a/__tests__/interpolate/Interpolate_transform_test.res
+++ b/__tests__/interpolate/Interpolate_transform_test.res
@@ -47,8 +47,8 @@ describe("Interpolate_transform", () => {
     })
 
     it("should interpolate a skew in one dimension property", () => {
-      let from = "skewZ(5deg)"
-      let to_ = "skewZ(60deg)"
+      let from = "skewX(5deg)"
+      let to_ = "skewX(60deg)"
 
       open Expect
       expect(
@@ -57,7 +57,7 @@ describe("Interpolate_transform", () => {
           ~domain=(from, to_),
           ~value=75.,
         ),
-      ) |> toEqual("skewZ(32.5deg)")
+      ) |> toEqual("skewX(32.5deg)")
     })
 
     it("should interpolate a perspective in one dimension property", () => {
@@ -189,4 +189,21 @@ describe("Interpolate_transform", () => {
       ) |> toEqual("translate(72.5px, 60px) scale(1.25, 15)")
     })
   })
+
+  it(
+    "should match transforms regardless of order, respecting the order of transforms in the from property in the output",
+    () => {
+      let from = "translate(45px, 100px) scale(1, 5)"
+      let to_ = "scale(1.5, 25) translate(100px, 20px)"
+
+      open Expect
+      expect(
+        Interpolate_transform.interpolateTransforms(
+          ~range=(0., 150.),
+          ~domain=(from, to_),
+          ~value=75.,
+        ),
+      ) |> toEqual("translate(72.5px, 60px) scale(1.25, 15)")
+    },
+  )
 })

--- a/src/interpolaters/Interpolate_transform.bs.js
+++ b/src/interpolaters/Interpolate_transform.bs.js
@@ -2,6 +2,7 @@
 
 import * as $$Array from "bs-platform/lib/es6/array.js";
 import * as Js_exn from "bs-platform/lib/es6/js_exn.js";
+import * as Js_dict from "bs-platform/lib/es6/js_dict.js";
 import * as Caml_array from "bs-platform/lib/es6/caml_array.js";
 import * as Belt_Option from "bs-platform/lib/es6/belt_Option.js";
 import * as Caml_option from "bs-platform/lib/es6/caml_option.js";
@@ -42,15 +43,25 @@ function interpolateTransform(param, param$1, value) {
   return Belt_Option.getWithDefault(Caml_option.nullable_to_opt(fromTransform.transformProperty), "") + ("(" + (transforms.join(", ") + ")"));
 }
 
+function populateTransformRegistry(transforms) {
+  return transforms.reduce((function (registry, t) {
+                var property = t.substring(0, t.indexOf("("));
+                registry[property] = t;
+                return registry;
+              }), {});
+}
+
 function interpolateTransforms(range, param, value) {
   var dlTransforms = Parse_transform.parseTransforms(param[0]);
   var dhTransforms = Parse_transform.parseTransforms(param[1]);
-  return $$Array.mapi((function (i, t) {
-                  return interpolateTransform(range, [
-                              t,
-                              Caml_array.get(dhTransforms, i)
-                            ], value);
-                }), dlTransforms).join(" ");
+  var dlTransformRegistry = populateTransformRegistry(dlTransforms);
+  var dhTransfromRegistry = populateTransformRegistry(dhTransforms);
+  return Js_dict.entries(dlTransformRegistry).map(function (param) {
+                return interpolateTransform(range, [
+                            param[1],
+                            dhTransfromRegistry[param[0]]
+                          ], value);
+              }).join(" ");
 }
 
 export {

--- a/src/parsers/Parse_transform.bs.js
+++ b/src/parsers/Parse_transform.bs.js
@@ -4,7 +4,7 @@ import * as $$Array from "bs-platform/lib/es6/array.js";
 import * as Parse_unit from "./Parse_unit.bs.js";
 import * as Parse_number from "./Parse_number.bs.js";
 
-var _map = {"translate":"translate","translateX":"translateX","translateY":"translateY","translateZ":"translateZ","skew":"skew","skewX":"skewX","skewY":"skewY","skewZ":"skewZ","rotate":"rotate","rotateX":"rotateX","rotateY":"rotateY","rotateZ":"rotateZ","scale":"scale","scaleX":"scaleX","scaleY":"scaleY","scaleZ":"scaleZ","perspective":"perspective"};
+var _map = {"translate":"translate","translateX":"translateX","translateY":"translateY","translateZ":"translateZ","translate3d":"translate3d","skew":"skew","skewX":"skewX","skewY":"skewY","rotate":"rotate","rotateX":"rotateX","rotateY":"rotateY","rotateZ":"rotateZ","rotate3d":"rotate3d","scale":"scale","scaleX":"scaleX","scaleY":"scaleY","scaleZ":"scaleZ","scale3d":"scale3d","perspective":"perspective","matrix":"matrix","matrix3d":"matrix3d"};
 
 var transformRe = /(\w+)\(([^)]*)\)/g;
 

--- a/src/parsers/Parse_transform.res
+++ b/src/parsers/Parse_transform.res
@@ -4,19 +4,23 @@ type transformProperties = [
   | #translateX
   | #translateY
   | #translateZ
+  | #translate3d
   | #skew
   | #skewX
   | #skewY
-  | #skewZ
   | #rotate
   | #rotateX
   | #rotateY
   | #rotateZ
+  | #rotate3d
   | #scale
   | #scaleX
   | #scaleY
   | #scaleZ
+  | #scale3d
   | #perspective
+  | #matrix
+  | #matrix3d
 ]
 
 let transformRe = %re("/(\w+)\(([^)]*)\)/g")


### PR DESCRIPTION
This PR fixes a deficiency in `renature`'s interpolator implementation for `transform`. Currently, if you're animating multiple `transform` properties, we rely on users specifying properties in a consistent order between `from` and `to`. For example, with a config like the following:

```typescript
{
  from: {
    transform: 'translateX(10px) skewY(3deg)',
  },
  to: {
    transform: 'skewY(6deg) translateX(20px)'
  }
}
```

we get improperly interpolated values, because the interpolator is matching based on position (i.e. `translateX` in `from` gets matched to `skewY` in `to`) rather than by property. This PR fixes this by capturing interpolated properties in an internal registry, i.e. a normalized map of transform properties and their values. With this patch, the above config works just fine!

There's one other core area where we can improve the implementation, which will also have bearing on how we handle the `controller.set` API. This involves providing an "animatable none" value for each `from` / `to` value. For example, if we have a config like:

```typescript
{
  from: {
    transform: 'translateX(10px) skewY(3deg)',
  },
  to: {
    transform: 'skewY(6deg) translateX(20px) rotate(5deg)'
  }
}
```

we'd like to infer based on the presence of `rotate(5deg)` in the `to` config a starting position of `rotate(0deg)` in the `from` config. This will be a separate issue and come in a separate release. This patch will go out as `renature` v0.7.2!