### PR TITLE
fix: modify the correct index for elements animated by controller.set

### DIFF
--- a/docs/src/screens/gallery/samples/basic.js
+++ b/docs/src/screens/gallery/samples/basic.js
@@ -4,8 +4,8 @@ import { useGravity } from 'renature';
 
 function Basic() {
   const [props] = useGravity({
-    from: { transform: 'translateX(-200px)' },
-    to: { transform: 'translateX(200px)' },
+    from: { transform: 'translateX(-100px)' },
+    to: { transform: 'translateX(100px)' },
     config: {
       moverMass: 10000,
       attractorMass: 1000000000000,

--- a/src/hooks/useFluidResistanceGroup.ts
+++ b/src/hooks/useFluidResistanceGroup.ts
@@ -91,6 +91,7 @@ export const useFluidResistanceGroup = <
     (target, idx) => {
       const updatingElements =
         typeof idx !== 'undefined' ? [elements[idx]] : elements;
+      let start = () => {};
 
       updatingElements.forEach((el, i) => {
         // Derive props based on the original index, if passed, or the mapped
@@ -108,7 +109,7 @@ export const useFluidResistanceGroup = <
         // Determine the maximum position the mover will reach based on the configuration.
         const maxPosition = getFluidPositionAtTerminalVelocity(el.config);
 
-        const { elements: updatedElements, start } = fluidResistanceGroup([
+        const { elements: updatedElements, start: run } = fluidResistanceGroup([
           {
             ref: el.ref,
             config: el.config,
@@ -131,9 +132,11 @@ export const useFluidResistanceGroup = <
           },
         ]);
 
-        elements[i].ref = updatedElements[i].ref;
-        start();
+        elements[idx ?? i].ref = updatedElements[i].ref;
+        start = run;
       });
+
+      start();
     },
     [fn, elements]
   );

--- a/src/hooks/useFrictionGroup.ts
+++ b/src/hooks/useFrictionGroup.ts
@@ -101,6 +101,7 @@ export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
     (target, idx) => {
       const updatingElements =
         typeof idx !== 'undefined' ? [elements[idx]] : elements;
+      let start = () => {};
 
       updatingElements.forEach((el, i) => {
         // Derive props based on the original index, if passed, or the mapped
@@ -118,7 +119,7 @@ export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
         // Determine the maximum position the mover will reach based on the configuration.
         const maxPosition = getMaxDistanceFriction(el.config);
 
-        const { elements: updatedElements, start } = frictionGroup([
+        const { elements: updatedElements, start: run } = frictionGroup([
           {
             ref: el.ref,
             config: el.config,
@@ -141,9 +142,11 @@ export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
           },
         ]);
 
-        elements[i].ref = updatedElements[i].ref;
-        start();
+        elements[idx ?? i].ref = updatedElements[i].ref;
+        start = run;
       });
+
+      start();
     },
     [fn, elements]
   );

--- a/src/hooks/useGravityGroup.ts
+++ b/src/hooks/useGravityGroup.ts
@@ -94,6 +94,7 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
     (target, idx) => {
       const updatingElements =
         typeof idx !== 'undefined' ? [elements[idx]] : elements;
+      let start = () => {};
 
       updatingElements.forEach((el, i) => {
         // Derive props based on the original index, if passed, or the mapped
@@ -108,7 +109,7 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
           to,
         });
 
-        const { elements: updatedElements, start } = gravityGroup([
+        const { elements: updatedElements, start: run } = gravityGroup([
           {
             ref: el.ref,
             config: el.config,
@@ -131,9 +132,11 @@ export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
           },
         ]);
 
-        elements[i].ref = updatedElements[i].ref;
-        start();
+        elements[idx ?? i].ref = updatedElements[i].ref;
+        start = run;
       });
+
+      start();
     },
     [fn, elements]
   );

--- a/stories/index.css
+++ b/stories/index.css
@@ -94,3 +94,10 @@ body {
 .stack-horizontal > * + * {
   margin-left: 1rem;
 }
+
+.letter {
+  font-weight: 700;
+  color: var(--color-renature);
+  font-size: 4rem;
+  opacity: 0;
+}

--- a/stories/useFrictionGroup.stories.tsx
+++ b/stories/useFrictionGroup.stories.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useLayoutEffect, useState, FC } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useEffect,
+  useState,
+  FC,
+} from 'react';
 import { withKnobs, number } from '@storybook/addon-knobs';
 
 import { useFrictionGroup } from '../src';
@@ -176,5 +182,52 @@ export const FrictionGroupSVG: FC = () => {
         {...nodes[2]}
       />
     </svg>
+  );
+};
+
+const RENATURE = 'RENATURE';
+const translateDirection = () => (Math.random() > 0.5 ? 1 : -1);
+const translateMagnitude = () => Math.floor(Math.random() * 200);
+
+export const FrictionGroupSet: FC = () => {
+  const [nodes, controller] = useFrictionGroup(RENATURE.length, (i) => ({
+    from: {
+      opacity: 0,
+    },
+    to: {
+      opacity: 1,
+    },
+    delay: i * 100,
+  }));
+
+  useEffect(() => {
+    let count = 0;
+
+    const intervalId = setInterval(() => {
+      nodes.forEach((_, i) => {
+        const translate =
+          count % 2 === 0
+            ? `translate(${translateMagnitude() * translateDirection()}px, ${
+                translateMagnitude() * translateDirection()
+              }px)`
+            : `translate(0px, 0px)`;
+
+        controller.set({ transform: translate }, i);
+      });
+
+      count += 1;
+    }, 2000);
+
+    return () => clearInterval(intervalId);
+  }, [nodes, controller]);
+
+  return (
+    <div className="stack-horizontal">
+      {nodes.map((props, i) => (
+        <span key={i} className="letter" {...props}>
+          {RENATURE[i]}
+        </span>
+      ))}
+    </div>
   );
 };


### PR DESCRIPTION
This PR adds one important fix to the `controller.set` API.

When invoking `controller.set` with the optional `i` parameter, we apply some special logic to ensure that we reference the proper `props` function to create the physics tween for the element at index `i` in the grouped animation array. However, we were failing to apply this same logic when we were mutating the `ref` at the end of `controller.set`. This could result in bugs where one element would just stop animating (notice the "R" just stuck at the right side of the screen 😂).

![20210204_renature_bug](https://user-images.githubusercontent.com/19421190/106922752-9853fc80-66ca-11eb-9768-1febecccd795.gif)

This PR fixes that bug! In addition, it adds some logic to minimize our calls to `start`. Rather than calling `start` once per element (which doesn't enqueue extra RAF calls but does still push an extra function call to the stack), we call it _once_ for all elements after their new `ref`s have been assigned. A small optimization, but good to have!