### PR TITLE
perf: add useForceGroup hook to consolidate animation logic

### DIFF
--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -171,7 +171,7 @@ const [props] = use<Force>Group(n: number, fn: (index: number) => Config);
 `useGravityGroup` will animate `n` elements using Newton's Law of Universal Gravitation. It takes the form:
 
 ```typescript
-const [props, controller] = useGravityGroup(n: number, fn: (index: number) => UseGravityArgs)
+const [props, controller] = useGravityGroup(n: number, fn: (index: number) => UseGravityParams)
 ```
 
 The configuration object returned by `fn` should match that defined in the [`useGravity`](#usegravity) section above.
@@ -216,7 +216,7 @@ function GravityGroup() {
 `useFrictionGroup` will animate `n` elements using the standard equation of friction. It takes the form:
 
 ```typescript
-const [props, controller] = useFrictionGroup(n: number, fn: (index: number) => UseFrictionArgs)
+const [props, controller] = useFrictionGroup(n: number, fn: (index: number) => UseFrictionParams)
 ```
 
 The configuration object returned by `fn` should match that defined in the [`useFriction`](#usefriction) section above.
@@ -265,7 +265,7 @@ function FrictionGroup() {
 `useFluidResistanceGroup` will animate `n` elements using the standard drag equation. It takes the form:
 
 ```typescript
-const [props, controller] = useFluidResistanceGroup(n: number, fn: (index: number) => UseFluidResistanceArgs)
+const [props, controller] = useFluidResistanceGroup(n: number, fn: (index: number) => UseFluidResistanceParams)
 ```
 
 The configuration object returned by `fn` should match that defined in the [`useFluidResistance`](#usefluidresistance) section above.

--- a/src/hooks/useFluidResistance.ts
+++ b/src/hooks/useFluidResistance.ts
@@ -4,7 +4,7 @@ import { Controller, fluidResistanceDefaultConfig } from '../animation';
 
 import {
   useFluidResistanceGroup,
-  UseFluidResistanceArgs,
+  UseFluidResistanceParams,
 } from './useFluidResistanceGroup';
 
 export const useFluidResistance = <E extends HTMLElement | SVGElement = any>({
@@ -17,7 +17,7 @@ export const useFluidResistance = <E extends HTMLElement | SVGElement = any>({
   onFrame,
   onAnimationComplete,
   disableHardwareAcceleration,
-}: UseFluidResistanceArgs): [{ ref: RefObject<E> }, Controller] => {
+}: UseFluidResistanceParams): [{ ref: RefObject<E> }, Controller] => {
   const [props, controller] = useFluidResistanceGroup(1, () => ({
     from,
     to,

--- a/src/hooks/useFluidResistanceGroup.ts
+++ b/src/hooks/useFluidResistanceGroup.ts
@@ -1,28 +1,18 @@
-import {
-  createRef,
-  useRef,
-  useMemo,
-  useLayoutEffect,
-  useCallback,
-  CSSProperties,
-  RefObject,
-} from 'react';
+import type { RefObject } from 'react';
 
-import { CSSPairs, getInterpolatorsForPairs, deriveStyle } from '../parsers';
+import type { CSSPairs } from '../parsers';
 import {
   FluidResistanceConfig,
-  fluidResistanceDefaultConfig,
-  fluidResistanceGroup,
   HooksParams,
   Controller,
-  AnimatingElement,
-  AnimationCache,
+  fluidResistanceDefaultConfig,
+  fluidResistanceGroup,
 } from '../animation';
 import { getFluidPositionAtTerminalVelocity } from '../forces';
 
-import { onUpdate, onComplete } from './shared';
+import { useForceGroup } from './useForceGroup';
 
-export type UseFluidResistanceArgs = CSSPairs &
+export type UseFluidResistanceParams = CSSPairs &
   HooksParams & {
     config?: FluidResistanceConfig;
   };
@@ -31,128 +21,13 @@ export const useFluidResistanceGroup = <
   E extends HTMLElement | SVGElement = any
 >(
   n: number,
-  fn: (index: number) => UseFluidResistanceArgs
-): [{ ref: RefObject<E> }[], Controller] => {
-  // Set up a cache to store interpolated CSS state.
-  const cache = useRef<AnimationCache>(new Map());
-
-  const { elements, start, stop, pause } = useMemo(() => {
-    const animatingElements: AnimatingElement<
-      FluidResistanceConfig,
-      E
-    >[] = new Array(n).fill(undefined).map((_, i) => {
-      // Run the supplied config generator for each element to animate.
-      const props = fn(i);
-
-      // Create the ref to store the animating element.
-      const ref = createRef<E>();
-
-      // Derive interpolator functions for the supplied CSS properties.
-      const interpolators = getInterpolatorsForPairs(
-        {
-          from: cache.current.get(i) ?? props.from,
-          to: props.to,
-        },
-        props.disableHardwareAcceleration
-      );
-      const config = props.config || fluidResistanceDefaultConfig;
-
-      // Determine the maximum position the mover will reach based on the configuration.
-      const maxPosition = getFluidPositionAtTerminalVelocity(config);
-
-      return {
-        ref,
-        config,
-        onUpdate: onUpdate({
-          interpolators,
-          maxPosition,
-          dimension: 'y',
-          ref,
-          i,
-          cache,
-          onFrame: props.onFrame,
-        }),
-        onComplete: onComplete({
-          interpolators,
-          ref,
-          i,
-          cache,
-        }),
-        infinite: props.infinite,
-        delay: props.delay,
-        pause: props.pause,
-      };
-    });
-
-    return fluidResistanceGroup(animatingElements);
-  }, [n, fn]);
-
-  const set = useCallback<(target: CSSProperties, idx?: number) => void>(
-    (target, idx) => {
-      const updatingElements =
-        typeof idx !== 'undefined' ? [elements[idx]] : elements;
-      let start = () => {};
-
-      updatingElements.forEach((el, i) => {
-        // Derive props based on the original index, if passed, or the mapped
-        // index if calling controller.set on all elements.
-        const props = fn(idx ?? i);
-
-        // Derive the element's current style for the given to property.
-        const { from, to } = deriveStyle(el.ref.current, target);
-
-        const interpolators = getInterpolatorsForPairs({
-          from,
-          to,
-        });
-
-        // Determine the maximum position the mover will reach based on the configuration.
-        const maxPosition = getFluidPositionAtTerminalVelocity(el.config);
-
-        const { elements: updatedElements, start: run } = fluidResistanceGroup([
-          {
-            ref: el.ref,
-            config: el.config,
-            onUpdate: onUpdate({
-              interpolators,
-              maxPosition,
-              dimension: 'x',
-              ref: el.ref,
-              i,
-              cache,
-              onFrame: props.onFrame,
-            }),
-            onComplete: onComplete({
-              interpolators,
-              ref: el.ref,
-              i,
-              cache,
-            }),
-            infinite: el.infinite,
-          },
-        ]);
-
-        elements[idx ?? i].ref = updatedElements[i].ref;
-        start = run;
-      });
-
-      start();
-    },
-    [fn, elements]
-  );
-
-  useLayoutEffect(() => {
-    start();
-
-    return stop;
-  }, [start, stop]);
-
-  const startAll = useCallback(() => start({ isImperativeStart: true }), [
-    start,
-  ]);
-
-  return [
-    elements.map(({ ref }) => ({ ref })),
-    { start: startAll, stop, pause, set },
-  ];
-};
+  fn: (index: number) => UseFluidResistanceParams
+): [{ ref: RefObject<E> }[], Controller] =>
+  useForceGroup<FluidResistanceConfig, E>({
+    n,
+    fn,
+    defaultConfig: fluidResistanceDefaultConfig,
+    getMaxDistance: getFluidPositionAtTerminalVelocity,
+    deriveGroup: fluidResistanceGroup,
+    dimension: 'y',
+  });

--- a/src/hooks/useForceGroup.ts
+++ b/src/hooks/useForceGroup.ts
@@ -1,0 +1,163 @@
+import {
+  createRef,
+  useRef,
+  useMemo,
+  useLayoutEffect,
+  useCallback,
+  CSSProperties,
+  RefObject,
+} from 'react';
+
+import { CSSPairs, getInterpolatorsForPairs, deriveStyle } from '../parsers';
+import {
+  HooksParams,
+  Controller,
+  AnimatingElement,
+  AnimationCache,
+  AnimationGroup,
+} from '../animation';
+
+import { onComplete, onUpdate } from './shared';
+
+type UseForceGroupConfig<C> = CSSPairs & HooksParams & { config?: C };
+
+interface UseForceGroupParams<C, E extends HTMLElement | SVGElement> {
+  n: number;
+  fn: (index: number) => UseForceGroupConfig<C>;
+  defaultConfig: C;
+  getMaxDistance: (config: C) => number;
+  deriveGroup: (elements: AnimatingElement<C, E>[]) => AnimationGroup<C>;
+  dimension: 'x' | 'y';
+}
+
+export const useForceGroup = <C, E extends HTMLElement | SVGElement>({
+  n,
+  fn,
+  defaultConfig,
+  getMaxDistance,
+  deriveGroup,
+  dimension,
+}: UseForceGroupParams<C, E>): [{ ref: RefObject<E> }[], Controller] => {
+  // Set up a cache to store interpolated CSS state.
+  const cache = useRef<AnimationCache>(new Map());
+
+  const { elements, start, stop, pause } = useMemo(() => {
+    const animatingElements: AnimatingElement<C, E>[] = new Array(n)
+      .fill(undefined)
+      .map((_, i) => {
+        // Run the supplied config generator for each element to animate.
+        const props = fn(i);
+
+        // Create the ref to store the animating element.
+        const ref = createRef<E>();
+
+        // Derive interpolator functions for the supplied CSS properties.
+        // Read from the cache, if populated, to determine the from value.
+        const interpolators = getInterpolatorsForPairs(
+          {
+            from: cache.current.get(i) ?? props.from,
+            to: props.to,
+          },
+          props.disableHardwareAcceleration
+        );
+        const config = props.config || defaultConfig;
+
+        // Determine the maximum position the mover will reach based on the configuration.
+        const maxPosition = getMaxDistance(config);
+
+        return {
+          ref,
+          config,
+          onUpdate: onUpdate({
+            interpolators,
+            maxPosition,
+            dimension,
+            ref,
+            i,
+            cache,
+            onFrame: props.onFrame,
+          }),
+          onComplete: onComplete({
+            interpolators,
+            ref,
+            i,
+            cache,
+          }),
+          infinite: props.infinite,
+          delay: props.delay,
+          pause: props.pause,
+        };
+      });
+
+    return deriveGroup(animatingElements);
+  }, [n, fn, defaultConfig, getMaxDistance, deriveGroup, dimension]);
+
+  useLayoutEffect(() => {
+    start();
+
+    return stop;
+  }, [start, stop]);
+
+  const startAll = useCallback(() => start({ isImperativeStart: true }), [
+    start,
+  ]);
+
+  const set = useCallback<(target: CSSProperties, idx?: number) => void>(
+    (target, idx) => {
+      const updatingElements =
+        typeof idx !== 'undefined' ? [elements[idx]] : elements;
+      let start = () => {};
+
+      updatingElements.forEach((el, i) => {
+        // Derive props based on the original index, if passed, or the mapped
+        // index if calling controller.set on all elements.
+        const props = fn(idx ?? i);
+
+        // Derive the element's current style for the given to property.
+        const { from, to } = deriveStyle(el.ref.current, target);
+
+        const interpolators = getInterpolatorsForPairs({
+          from,
+          to,
+        });
+
+        // Determine the maximum position the mover will reach based on the configuration.
+        const maxPosition = getMaxDistance(el.config);
+
+        const { elements: updatedElements, start: run } = deriveGroup([
+          {
+            ref: el.ref,
+            config: el.config,
+            onUpdate: onUpdate({
+              interpolators,
+              maxPosition,
+              dimension: 'x',
+              ref: el.ref,
+              i,
+              cache,
+              onFrame: props.onFrame,
+            }),
+            onComplete: onComplete({
+              interpolators,
+              ref: el.ref,
+              i,
+              cache,
+            }),
+            infinite: el.infinite,
+          },
+        ]);
+
+        elements[idx ?? i].ref = updatedElements[i].ref;
+        start = run;
+      });
+
+      start();
+    },
+    [fn, elements, getMaxDistance, deriveGroup]
+  );
+
+  return [
+    elements.map(({ ref }) => ({ ref })),
+    { start: startAll, stop, pause, set },
+  ];
+};

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -2,7 +2,7 @@ import type { RefObject } from 'react';
 
 import { Controller, frictionDefaultConfig } from '../animation';
 
-import { useFrictionGroup, UseFrictionArgs } from './useFrictionGroup';
+import { useFrictionGroup, UseFrictionParams } from './useFrictionGroup';
 
 export const useFriction = <E extends HTMLElement | SVGElement = any>({
   from,
@@ -14,7 +14,7 @@ export const useFriction = <E extends HTMLElement | SVGElement = any>({
   onFrame,
   onAnimationComplete,
   disableHardwareAcceleration = false,
-}: UseFrictionArgs): [{ ref: RefObject<E> }, Controller] => {
+}: UseFrictionParams): [{ ref: RefObject<E> }, Controller] => {
   const [props, controller] = useFrictionGroup<E>(1, () => ({
     from,
     to,

--- a/src/hooks/useFrictionGroup.ts
+++ b/src/hooks/useFrictionGroup.ts
@@ -1,158 +1,31 @@
-import {
-  createRef,
-  useRef,
-  useMemo,
-  useLayoutEffect,
-  useCallback,
-  CSSProperties,
-  RefObject,
-} from 'react';
+import type { RefObject } from 'react';
 
-import { CSSPairs, getInterpolatorsForPairs, deriveStyle } from '../parsers';
+import type { CSSPairs } from '../parsers';
 import {
   FrictionConfig,
   frictionDefaultConfig,
   frictionGroup,
   HooksParams,
   Controller,
-  AnimatingElement,
-  AnimationCache,
 } from '../animation';
 import { getMaxDistanceFriction } from '../forces';
 
-import { onComplete, onUpdate } from './shared';
+import { useForceGroup } from './useForceGroup';
 
-export type UseFrictionArgs = CSSPairs &
+export type UseFrictionParams = CSSPairs &
   HooksParams & {
     config?: FrictionConfig;
   };
 
 export const useFrictionGroup = <E extends HTMLElement | SVGElement = any>(
   n: number,
-  fn: (index: number) => UseFrictionArgs
-): [{ ref: RefObject<E> }[], Controller] => {
-  // Set up a cache to store interpolated CSS state.
-  const cache = useRef<AnimationCache>(new Map());
-
-  const { elements, start, stop, pause } = useMemo(() => {
-    const animatingElements: AnimatingElement<FrictionConfig, E>[] = new Array(
-      n
-    )
-      .fill(undefined)
-      .map((_, i) => {
-        // Run the supplied config generator for each element to animate.
-        const props = fn(i);
-
-        // Create the ref to store the animating element.
-        const ref = createRef<E>();
-
-        // Derive interpolator functions for the supplied CSS properties.
-        // Read from the cache, if populated, to determine the from value.
-        const interpolators = getInterpolatorsForPairs(
-          {
-            from: cache.current.get(i) ?? props.from,
-            to: props.to,
-          },
-          props.disableHardwareAcceleration
-        );
-        const config = props.config || frictionDefaultConfig;
-
-        // Determine the maximum position the mover will reach based on the configuration.
-        const maxPosition = getMaxDistanceFriction(config);
-
-        return {
-          ref,
-          config,
-          onUpdate: onUpdate({
-            interpolators,
-            maxPosition,
-            dimension: 'x',
-            ref,
-            i,
-            cache,
-            onFrame: props.onFrame,
-          }),
-          onComplete: onComplete({
-            interpolators,
-            ref,
-            i,
-            cache,
-          }),
-          infinite: props.infinite,
-          delay: props.delay,
-          pause: props.pause,
-        };
-      });
-
-    return frictionGroup(animatingElements);
-  }, [n, fn]);
-
-  useLayoutEffect(() => {
-    start();
-
-    return stop;
-  }, [start, stop]);
-
-  const startAll = useCallback(() => start({ isImperativeStart: true }), [
-    start,
-  ]);
-
-  const set = useCallback<(target: CSSProperties, idx?: number) => void>(
-    (target, idx) => {
-      const updatingElements =
-        typeof idx !== 'undefined' ? [elements[idx]] : elements;
-      let start = () => {};
-
-      updatingElements.forEach((el, i) => {
-        // Derive props based on the original index, if passed, or the mapped
-        // index if calling controller.set on all elements.
-        const props = fn(idx ?? i);
-
-        // Derive the element's current style for the given to property.
-        const { from, to } = deriveStyle(el.ref.current, target);
-
-        const interpolators = getInterpolatorsForPairs({
-          from,
-          to,
-        });
-
-        // Determine the maximum position the mover will reach based on the configuration.
-        const maxPosition = getMaxDistanceFriction(el.config);
-
-        const { elements: updatedElements, start: run } = frictionGroup([
-          {
-            ref: el.ref,
-            config: el.config,
-            onUpdate: onUpdate({
-              interpolators,
-              maxPosition,
-              dimension: 'x',
-              ref: el.ref,
-              i,
-              cache,
-              onFrame: props.onFrame,
-            }),
-            onComplete: onComplete({
-              interpolators,
-              ref: el.ref,
-              i,
-              cache,
-            }),
-            infinite: el.infinite,
-          },
-        ]);
-
-        elements[idx ?? i].ref = updatedElements[i].ref;
-        start = run;
-      });
-
-      start();
-    },
-    [fn, elements]
-  );
-
-  return [
-    elements.map(({ ref }) => ({ ref })),
-    { start: startAll, stop, pause, set },
-  ];
-};
+  fn: (index: number) => UseFrictionParams
+): [{ ref: RefObject<E> }[], Controller] =>
+  useForceGroup<FrictionConfig, E>({
+    n,
+    fn,
+    defaultConfig: frictionDefaultConfig,
+    getMaxDistance: getMaxDistanceFriction,
+    deriveGroup: frictionGroup,
+    dimension: 'x',
+  });

--- a/src/hooks/useGravity.ts
+++ b/src/hooks/useGravity.ts
@@ -2,7 +2,7 @@ import type { RefObject } from 'react';
 
 import { Controller, gravityDefaultConfig } from '../animation';
 
-import { useGravityGroup, UseGravityArgs } from './useGravityGroup';
+import { useGravityGroup, UseGravityParams } from './useGravityGroup';
 
 export const useGravity = <E extends HTMLElement | SVGElement = any>({
   from,
@@ -14,7 +14,7 @@ export const useGravity = <E extends HTMLElement | SVGElement = any>({
   onFrame,
   onAnimationComplete,
   disableHardwareAcceleration,
-}: UseGravityArgs): [{ ref: RefObject<E> }, Controller] => {
+}: UseGravityParams): [{ ref: RefObject<E> }, Controller] => {
   const [props, controller] = useGravityGroup(1, () => ({
     from,
     to,

--- a/src/hooks/useGravityGroup.ts
+++ b/src/hooks/useGravityGroup.ts
@@ -1,148 +1,30 @@
-import {
-  createRef,
-  useRef,
-  useMemo,
-  useLayoutEffect,
-  useCallback,
-  CSSProperties,
-  RefObject,
-} from 'react';
+import type { RefObject } from 'react';
 
-import { CSSPairs, getInterpolatorsForPairs, deriveStyle } from '../parsers';
+import type { CSSPairs } from '../parsers';
 import {
   GravityConfig,
   gravityDefaultConfig,
   gravityGroup,
   HooksParams,
   Controller,
-  AnimatingElement,
-  AnimationCache,
 } from '../animation';
 
-import { onUpdate, onComplete } from './shared';
+import { useForceGroup } from './useForceGroup';
 
-export type UseGravityArgs = CSSPairs &
+export type UseGravityParams = CSSPairs &
   HooksParams & {
     config?: GravityConfig;
   };
 
 export const useGravityGroup = <E extends HTMLElement | SVGElement = any>(
   n: number,
-  fn: (index: number) => UseGravityArgs
-): [{ ref: RefObject<E> }[], Controller] => {
-  // Set up a cache to store interpolated CSS state.
-  const cache = useRef<AnimationCache>(new Map());
-
-  const { elements, start, stop, pause } = useMemo(() => {
-    const animatingElements: AnimatingElement<GravityConfig, E>[] = new Array(n)
-      .fill(undefined)
-      .map((_, i) => {
-        // Run the supplied config generator for each element to animate.
-        const props = fn(i);
-
-        // Create the ref to store the animating element.
-        const ref = createRef<E>();
-
-        // Derive interpolator functions for the supplied CSS properties.
-        const interpolators = getInterpolatorsForPairs(
-          {
-            from: cache.current.get(i) ?? props.from,
-            to: props.to,
-          },
-          props.disableHardwareAcceleration
-        );
-        const config = props.config || gravityDefaultConfig;
-
-        return {
-          ref,
-          config,
-          onUpdate: onUpdate({
-            interpolators,
-            maxPosition: config.r,
-            dimension: 'x',
-            ref,
-            i,
-            cache,
-            onFrame: props.onFrame,
-          }),
-          onComplete: onComplete({
-            interpolators,
-            ref,
-            i,
-            cache,
-          }),
-          infinite: props.infinite,
-          delay: props.delay,
-          pause: props.pause,
-        };
-      });
-
-    return gravityGroup(animatingElements);
-  }, [n, fn]);
-
-  useLayoutEffect(() => {
-    start();
-
-    return stop;
-  }, [start, stop]);
-
-  const startAll = useCallback(() => start({ isImperativeStart: true }), [
-    start,
-  ]);
-
-  const set = useCallback<(target: CSSProperties, idx?: number) => void>(
-    (target, idx) => {
-      const updatingElements =
-        typeof idx !== 'undefined' ? [elements[idx]] : elements;
-      let start = () => {};
-
-      updatingElements.forEach((el, i) => {
-        // Derive props based on the original index, if passed, or the mapped
-        // index if calling controller.set on all elements.
-        const props = fn(idx ?? i);
-
-        // Derive the element's current style for the given to property.
-        const { from, to } = deriveStyle(el.ref.current, target);
-
-        const interpolators = getInterpolatorsForPairs({
-          from,
-          to,
-        });
-
-        const { elements: updatedElements, start: run } = gravityGroup([
-          {
-            ref: el.ref,
-            config: el.config,
-            onUpdate: onUpdate({
-              interpolators,
-              maxPosition: el.config.r,
-              dimension: 'x',
-              ref: el.ref,
-              i,
-              cache,
-              onFrame: props.onFrame,
-            }),
-            onComplete: onComplete({
-              interpolators,
-              ref: el.ref,
-              i,
-              cache,
-            }),
-            infinite: el.infinite,
-          },
-        ]);
-
-        elements[idx ?? i].ref = updatedElements[i].ref;
-        start = run;
-      });
-
-      start();
-    },
-    [fn, elements]
-  );
-
-  return [
-    elements.map(({ ref }) => ({ ref })),
-    { start: startAll, stop, pause, set },
-  ];
-};
+  fn: (index: number) => UseGravityParams
+): [{ ref: RefObject<E> }[], Controller] =>
+  useForceGroup<GravityConfig, E>({
+    n,
+    fn,
+    defaultConfig: gravityDefaultConfig,
+    getMaxDistance: (config) => config.r,
+    deriveGroup: gravityGroup,
+    dimension: 'x',
+  });

--- a/stories/index.css
+++ b/stories/index.css
@@ -77,7 +77,7 @@ body {
 }
 
 .react-logo {
-  stroke: var(--color-renature-purple);
+  stroke: var(--color-renature);
   stroke-width: 3;
   fill: transparent;
 }


### PR DESCRIPTION
This PR is focused exclusively on bundle size optimizations 📦 

Previously, our `useFrictionGroup`, `useFluidResistanceGroup`, and `useGravityGroup` hooks duplicated a lot of logic. In the early days of `renature` this helped to reduce cognitive load by keeping each force clearly isolated, but it also opened up opportunities for feature drift across the hooks. This became even more apparent in the course of designing the `controller.set` API.

We now consolidate these three hooks in the form of a `useForceGroup` hook, which accepts several functions as parameters to compose more specific force hooks from the same base. Here's a look at its API:

```typescript
export const useForceGroup = <C, E extends HTMLElement | SVGElement>({
  // The number of elements to animate.
  n,
  // The callback function to invoke to derive the config for each animating element.
  fn,
  // The fallback config to use if no config is specified in fn.
  defaultConfig,
  // The function to calculate the max position achieved by the mover in the underlying physics simulation.
  getMaxDistance,
  // The function to apply the specified force over a group of animating elements and execute the animation in requestAnimationFrame.
  deriveGroup,
  // The axis in space that the physics simulation runs along, `'x' | 'y'`
  dimension,
}: UseForceGroupParams<C, E>): [{ ref: RefObject<E> }[], Controller] => {};
```

Ultimately, I think this change is a really important one for both:

1. Reducing bundle size, and
2. Consolidating logic in a centralized, predictable location for each hook.

This will be released in v0.8.2!