### PR TITLE
docs: document repeat API

### DIFF
--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -20,7 +20,7 @@ This document contains all information on `renature`'s public facing API.
 | `config`                      | `object?`                                   | Optional. The physics parameters used to model the selected force. This varies from force to force. See [Config](#config) below for specific force paramters. If no `config` is supplied, a default set of physics parameters will be supplied by `renature`. |
 | `pause`                       | `boolean?`                                  | Optional. Instructs `renature` to pause the animation on initial mount. If `true`, the animation will not run until `controller.start` is called or until a re-render occurs and `pause` evaluates to `false`. Defaults to `false`.                           |
 | `delay`                       | `number?`                                   | Optional. Instructs `renature` to delay the start of the animation by the provided number of milliseconds. Defaults to `undefined`.                                                                                                                           |
-| `infinite`                    | `boolean?`                                  | Optional. Instructs `renature` to restart the animation in the reverse direction when the animation completes in the forward direction, producing a "yoyo" effect. Defaults to `false`.                                                                       |
+| `repeat`                      | `number?`                                   | Optional. Instructs `renature` to repeat the animation a specific number of times. By default, animations will swap the `from` and `to` values when `repeat` is specified, producing a mirroring animation effect. Defaults to `0`.                           |
 | `onFrame`                     | `?(progress: number) => void`               | Optional. Supply a callback function that `renature` will execute on every call to `requestAnimationFrame`.                                                                                                                                                   |
 | `onAnimationComplete`         | `?() => void`                               | Optional. Supply a callback function that `renature` will run when your animation has completed. If the animation is unmounted before completing, `onAnimationComplete` _will not_ be called.                                                                 |
 | `disableHardwareAcceleration` | `boolean?`                                  | Optional. Prevent `renature` from applying optimizations that push compatible animations to the GPU.                                                                                                                                                          |
@@ -61,7 +61,7 @@ function GravityBasic() {
       attractorMass: 10000000000000,
       r: 10,
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return <div className="lp__m lp__m--lg" {...props} />;
@@ -105,7 +105,7 @@ function FrictionBasic() {
       mass: 300,
       initialVelocity: 10,
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return <div className="lp__m lp__m--lg" {...props} />;
@@ -151,7 +151,7 @@ function FluidResistanceBasic() {
       cDrag: 0.1,
       settle: true,
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return <div className="lp__m lp__m--lg" {...props} />;
@@ -197,7 +197,7 @@ function GravityGroup() {
       attractorMass: 10000000000000,
       r: 10,
     },
-    infinite: true,
+    repeat: Infinity,
     delay: i * 500,
   }));
 
@@ -243,7 +243,7 @@ function FrictionGroup() {
       initialVelocity: 5,
     },
     delay: i * 500,
-    infinite: true,
+    repeat: Infinity,
   }));
 
   return (
@@ -292,7 +292,7 @@ function FluidResistanceGroup() {
       settle: true,
     },
     delay: i * 500,
-    infinite: true,
+    repeat: Infinity,
   }));
 
   return (

--- a/docs/content/getting-started/controlling-animation-states.md
+++ b/docs/content/getting-started/controlling-animation-states.md
@@ -5,7 +5,7 @@ order: 3
 
 ## Controlling Animation States
 
-In this section, we'll cover how to control animation states in `renature`. This includes starting, stopping, and delaying animations, as well as running them infinitely.
+In this section, we'll cover how to control animation states in `renature`. This includes starting, stopping, and delaying animations, as well as running them infinitely or a pre-specified number of iterations.
 
 ## The `Controller` API
 
@@ -65,7 +65,7 @@ function PauseAnimation() {
       transform: 'rotate(360deg) scale(0)',
     },
     pause: true, // Signal that the animation should not run on mount.
-    infinite: true,
+    repeat: Infinity,
   });
 
   return (
@@ -106,7 +106,7 @@ function StopAnimation() {
     to: {
       transform: 'rotate(360deg) scale(1)',
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return (
@@ -144,7 +144,7 @@ function DelayedMover() {
       r: 7.5,
     },
     delay: i * 500,
-    infinite: true,
+    repeat: Infinity,
   }));
 
   return (
@@ -159,7 +159,7 @@ function DelayedMover() {
 
 ### Running Animations Infinitely
 
-Sometimes you want your animations to run infinitely, without stopping. You can do this with `renature` by applying `infinite` to your animation configuration. Of course, you can still use `controller.stop` to end the animation whenever you want to.
+Sometimes you want your animations to run infinitely, without stopping. You can do this with `renature` by applying `repeat: Infinity` to your animation configuration. Of course, you can still use `controller.stop` to end the animation whenever you want to.
 
 ```js live=true
 import React from 'react';
@@ -180,7 +180,7 @@ function InfiniteMover() {
       background: getRandomHex(),
       borderRadius: `${Math.floor(Math.random() * 100)}%`,
     },
-    infinite: true, // Specify that the animation should run infinitely.
+    repeat: Infinity, // Specify that the animation should run infinitely.
     delay: i * 500,
   }));
 
@@ -195,6 +195,51 @@ function InfiniteMover() {
 ```
 
 Infinite animations oscillate between your `from` and `to` states, creating a "yoyo" effect. They work by running the exact same underlying physics animation in a reversed direction.
+
+### Running Animations a Specific Number of Times
+
+`renature` also allows you to run an animation a specific number of times. To do this, specify a concrete number greater than 0 for the `repeat` parameter. For example:
+
+```js live=true
+import React from 'react';
+import { useFrictionGroup } from 'renature';
+
+function InfiniteMover() {
+  const getRandomHex = () =>
+    '#' + ((Math.random() * 0xffffff) << 0).toString(16).padStart(6, '0');
+
+  const [nodes] = useFrictionGroup(3, (i) => ({
+    from: {
+      transform: 'translateX(0px)',
+      background: getRandomHex(),
+      borderRadius: `${Math.floor(Math.random() * 100)}%`,
+    },
+    to: {
+      transform: 'translateX(50px)',
+      background: getRandomHex(),
+      borderRadius: `${Math.floor(Math.random() * 100)}%`,
+    },
+    repeat: 3, // Specify that the animation should repeat three times after the first run.
+    delay: i * 500,
+  }));
+
+  return (
+    <div className="lp__stack-h">
+      {nodes.map((props) => (
+        <div className="lp__m lp__m--lg" {...props} />
+      ))}
+    </div>
+  );
+}
+```
+
+The number specified in `repeat` determines how many times the animation runs **in addition to** the initial run. For example, the above animation runs as follows:
+
+1. Animates from the `from` configuration to the `to` configuration (initial run).
+2. Continually reverses `from` and `to` for the next three iterations, as specified by `repeat`.
+3. Comes to a stop.
+
+This behavior is quite useful when you want an animation to continue for a specific number of iterations and come to a neat stop. You can preemptively stop the animation using `controller.stop`.
 
 ### Setting Animations to Arbitrary States
 

--- a/docs/content/getting-started/grouped-animations.md
+++ b/docs/content/getting-started/grouped-animations.md
@@ -26,7 +26,7 @@ function GravityGroup() {
       borderRadius: '50%',
     },
     delay: i * 1000,
-    infinite: true,
+    repeat: Infinity,
   }));
 
   return (
@@ -48,7 +48,7 @@ import React from 'react';
 import { useFrictionGroup } from 'renature';
 
 function FrictionGroup() {
-  const getFromToForIndex = (i) => {
+  const getConfigForIndex = (i) => {
     switch (i) {
       case 0:
         return {
@@ -88,8 +88,8 @@ function FrictionGroup() {
   };
 
   const [nodes] = useFrictionGroup(3, (i) => ({
-    ...getFromToForIndex(i),
-    infinite: true,
+    ...getConfigForIndex(i),
+    repeat: Infinity,
   }));
 
   return (

--- a/docs/content/getting-started/your-first-animation.md
+++ b/docs/content/getting-started/your-first-animation.md
@@ -24,7 +24,7 @@ function Mover() {
       mass: 20,
       initialVelocity: 5,
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return <div className="lp__m lp__m--lg" {...props} />;
@@ -60,7 +60,7 @@ function MoverMultiple() {
       mass: 20,
       initialVelocity: 5,
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return <div className="lp__m lp__m--lg" {...props} />;

--- a/docs/package.json
+++ b/docs/package.json
@@ -41,7 +41,7 @@
     "react-static-plugin-react-router": "^7.4.2",
     "react-static-plugin-sitemap": "^7.4.2",
     "react-static-plugin-styled-components": "^7.3.0",
-    "renature": "^0.8.1",
+    "renature": "^0.9.0",
     "styled-components": "^5.2.0"
   },
   "devDependencies": {

--- a/docs/src/screens/gallery/samples/basic.js
+++ b/docs/src/screens/gallery/samples/basic.js
@@ -11,7 +11,7 @@ function Basic() {
       attractorMass: 1000000000000,
       r: 10,
     },
-    infinite: true
+    repeat: Infinity
   });
 
   return (

--- a/docs/src/screens/gallery/samples/box-shadow.js
+++ b/docs/src/screens/gallery/samples/box-shadow.js
@@ -17,7 +17,7 @@ function BoxShadow() {
       mass: 25,
       initialVelocity: 10
     },
-    infinite: true
+    repeat: Infinity
   });
 
   return (

--- a/docs/src/screens/gallery/samples/grouped-animations.js
+++ b/docs/src/screens/gallery/samples/grouped-animations.js
@@ -18,7 +18,7 @@ function FrictionGroup() {
       initialVelocity: 5,
     },
     delay: i * 500,
-    infinite: true,
+    repeat: Infinity,
   }));
 
   return (

--- a/docs/src/screens/gallery/samples/multiple-properties.js
+++ b/docs/src/screens/gallery/samples/multiple-properties.js
@@ -19,7 +19,7 @@ function Mover() {
       mass: 20,
       initialVelocity: 5,
     },
-    infinite: true,
+    repeat: Infinity,
   });
 
   return (

--- a/docs/src/screens/gallery/samples/path-tracing.js
+++ b/docs/src/screens/gallery/samples/path-tracing.js
@@ -59,7 +59,7 @@ function SVGPathTracing() {
     mu: 0.25,
     mass: 300,
     initialVelocity: 10,
-    infinite: true,
+    repeat: Infinity,
   }));
 
   return (

--- a/docs/src/screens/home/preview.js
+++ b/docs/src/screens/home/preview.js
@@ -31,7 +31,7 @@ function FrictionAnimation() {
       background: 'coral',
     },
     config: { mu: 0.5, mass: 300, initialVelocity: 10 },
-    infinite: true
+    repeat: Infinity
   });
 
   return (

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8762,10 +8762,10 @@ remove-trailing-separator@^1.0.1:
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
-renature@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/renature/-/renature-0.8.1.tgz#3a31996c4b57f9abfe52b1707345c469cbb2cd29"
-  integrity sha512-CEeWT/bnuQDMlqolO+Ml8osIEoT1quayihpOZdDQAKgHD+lZQLLlMjNfV7bI+Kre5K+TdZvmxA2OH1D7Rg880g==
+renature@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/renature/-/renature-0.9.0.tgz#d3a65b993760484e8c529d2f9de36d3e7c6c998b"
+  integrity sha512-B6B2rXQHs0qL9H+G3lJIc174MmjDLOGiaY+isYllJWFO8miAkWhaZAAPPyPYURRgO0+vWrCd7zjWrAl+QVq/cg==
 
 renderkid@^2.0.1:
   version "2.0.3"


### PR DESCRIPTION
This PR adds documentation for the new `repeat` API! The changes include:

- Adding a section on running animations a set number of times with the `repeat` API
- Updating the docs on infinite animations to specify the use of `repeat: Infinity`
- Updating all demos and interactive examples to use `repeat: Infinity`