### PR TITLE
fix: handle edge cases in repeat API

### DIFF
--- a/__tests__/animation/fluidResistance.spec.ts
+++ b/__tests__/animation/fluidResistance.spec.ts
@@ -162,7 +162,7 @@ describe('fluidResistance', () => {
     const mockElements: AnimatingElement<
       FluidResistanceConfig,
       HTMLElement
-    >[] = new Array(3).fill({ ...baseElement, repeat: 3 });
+    >[] = new Array(3).fill({ ...baseElement, repeat: 2 });
 
     const { start, elements } = fluidResistanceGroup(mockElements);
 
@@ -178,7 +178,7 @@ describe('fluidResistance', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Reverse && state.repeatCount === 1
+          state.playState === PlayState.Reverse && state.repeatCount === 0
       )
     ).toBe(true);
 
@@ -188,7 +188,7 @@ describe('fluidResistance', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Forward && state.repeatCount === 2
+          state.playState === PlayState.Forward && state.repeatCount === 1
       )
     ).toBe(true);
 
@@ -198,7 +198,7 @@ describe('fluidResistance', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Reverse && state.repeatCount === 3
+          state.playState === PlayState.Reverse && state.repeatCount === 2
       )
     ).toBe(true);
 

--- a/__tests__/animation/friction.spec.ts
+++ b/__tests__/animation/friction.spec.ts
@@ -169,7 +169,7 @@ describe('friction', () => {
     const mockElements: AnimatingElement<
       FrictionConfig,
       HTMLElement
-    >[] = new Array(3).fill({ ...baseElement, repeat: 3 });
+    >[] = new Array(3).fill({ ...baseElement, repeat: 2 });
 
     const { start, elements } = frictionGroup(mockElements);
 
@@ -185,7 +185,7 @@ describe('friction', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Reverse && state.repeatCount === 1
+          state.playState === PlayState.Reverse && state.repeatCount === 0
       )
     ).toBe(true);
 
@@ -195,7 +195,7 @@ describe('friction', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Forward && state.repeatCount === 2
+          state.playState === PlayState.Forward && state.repeatCount === 1
       )
     ).toBe(true);
 
@@ -205,7 +205,7 @@ describe('friction', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Reverse && state.repeatCount === 3
+          state.playState === PlayState.Reverse && state.repeatCount === 2
       )
     ).toBe(true);
 

--- a/__tests__/animation/gravity.spec.ts
+++ b/__tests__/animation/gravity.spec.ts
@@ -161,7 +161,7 @@ describe('gravity', () => {
     const mockElements: AnimatingElement<
       GravityConfig,
       HTMLElement
-    >[] = new Array(3).fill({ ...baseElement, repeat: 3 });
+    >[] = new Array(3).fill({ ...baseElement, repeat: 2 });
 
     const { start, elements } = gravityGroup(mockElements);
 
@@ -177,7 +177,7 @@ describe('gravity', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Reverse && state.repeatCount === 1
+          state.playState === PlayState.Reverse && state.repeatCount === 0
       )
     ).toBe(true);
 
@@ -187,7 +187,7 @@ describe('gravity', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Forward && state.repeatCount === 2
+          state.playState === PlayState.Forward && state.repeatCount === 1
       )
     ).toBe(true);
 
@@ -197,7 +197,7 @@ describe('gravity', () => {
     expect(
       elements.every(
         ({ state }) =>
-          state.playState === PlayState.Reverse && state.repeatCount === 3
+          state.playState === PlayState.Reverse && state.repeatCount === 2
       )
     ).toBe(true);
 

--- a/__tests__/animation/group.spec.ts
+++ b/__tests__/animation/group.spec.ts
@@ -25,7 +25,7 @@ describe('group', () => {
     complete: false,
     paused: false,
     delayed: false,
-    repeatCount: 0,
+    repeatCount: -1,
   };
 
   const baseElement: AnimatingElement<Record<string, unknown>, HTMLElement> = {

--- a/__tests__/rAF/update.spec.ts
+++ b/__tests__/rAF/update.spec.ts
@@ -191,6 +191,50 @@ describe('update', () => {
     expect(stop).toHaveBeenCalledTimes(1);
   });
 
+  it('should call onComplete if the repeatCount is not a positive integer (invariant)', () => {
+    const onComplete = jest.fn();
+
+    const element: StatefulAnimatingElement<
+      Record<string, unknown>,
+      HTMLElement
+    > = {
+      ...baseElement,
+      repeat: -5,
+      onComplete,
+      state: {
+        ...baseElement.state,
+        mover: {
+          ...baseElement.state.mover,
+          velocity: [2, 0],
+          position: [5, 0],
+        },
+        repeatCount: -1,
+      },
+    };
+
+    animatingElements.add(element);
+
+    const checkReversePlayState = jest.fn();
+    const applyForceForStep = jest.fn();
+    const checkStoppingCondition = jest.fn().mockImplementation(() => true);
+    const stop = jest.fn();
+
+    const loop = update({
+      animatingElements,
+      checkReversePlayState,
+      applyForceForStep,
+      checkStoppingCondition,
+    });
+
+    const timestamp = performance.now();
+    // Increment timestamp by 1000 / 60ms to mimic one frame elapsing
+    loop(timestamp + 1000 / 60, timestamp, stop);
+
+    expect(applyForceForStep).toHaveBeenCalledTimes(16);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
   it('should call onComplete if the animating element has reached its stopping condition', () => {
     const onComplete = jest.fn();
 

--- a/src/animation/fluidResistance.ts
+++ b/src/animation/fluidResistance.ts
@@ -148,7 +148,7 @@ export function fluidResistanceGroup(
     complete: false,
     paused: !!element.pause,
     delayed: !!element.delay,
-    repeatCount: 0,
+    repeatCount: -1,
   });
 
   return group(elements, initialState, {

--- a/src/animation/friction.ts
+++ b/src/animation/friction.ts
@@ -93,7 +93,7 @@ export function frictionGroup(
     complete: false,
     paused: !!element.pause,
     delayed: !!element.delay,
-    repeatCount: 0,
+    repeatCount: -1,
   });
 
   return group(elements, initialState, {

--- a/src/animation/gravity.ts
+++ b/src/animation/gravity.ts
@@ -130,7 +130,7 @@ export function gravityGroup(
     complete: false,
     paused: !!element.pause,
     delayed: !!element.delay,
-    repeatCount: 0,
+    repeatCount: -1,
   });
 
   return group(elements, initialState, {

--- a/src/animation/group.ts
+++ b/src/animation/group.ts
@@ -25,7 +25,6 @@ export function group<C>(
   elements.forEach((element) => {
     const animatingElement: StatefulAnimatingElement<C> = {
       ...element,
-      repeat: typeof element.repeat === 'number' ? element.repeat : 0,
       state: initialState(element),
     };
 

--- a/src/animation/group.ts
+++ b/src/animation/group.ts
@@ -25,6 +25,7 @@ export function group<C>(
   elements.forEach((element) => {
     const animatingElement: StatefulAnimatingElement<C> = {
       ...element,
+      repeat: typeof element.repeat === 'number' ? element.repeat : 0,
       state: initialState(element),
     };
 

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -47,7 +47,7 @@ export interface AnimatingElement<
   ref: RefObject<E>;
   config: C;
   onUpdate: VectorSetter;
-  onComplete: () => void;
+  onComplete: (playState?: PlayState) => void;
   repeat?: number;
   delay?: number;
   pause?: boolean;

--- a/src/rAF/update.ts
+++ b/src/rAF/update.ts
@@ -56,11 +56,14 @@ export function update<C>({
 
       // Conditions for stopping the physics animation.
       // If no repeat is specified and we've reached the stopping condition...
-      if (!element.repeat && checkStoppingCondition(element)) {
+      if (
+        (typeof element.repeat !== 'number' || element.repeat === 0) &&
+        checkStoppingCondition(element)
+      ) {
         element.onComplete();
         element.state.complete = true;
         // If repeat is specified and we've reached the repeat count.
-      } else if (element.repeat === element.state.repeatCount - 1) {
+      } else if (element.repeat === element.state.repeatCount) {
         element.onComplete(element.state.playState);
         element.state.complete = true;
       } else {

--- a/src/rAF/update.ts
+++ b/src/rAF/update.ts
@@ -55,11 +55,13 @@ export function update<C>({
       }
 
       // Conditions for stopping the physics animation.
-      if (
-        (!element.repeat && checkStoppingCondition(element)) ||
-        element.state.repeatCount === element.repeat
-      ) {
+      // If no repeat is specified and we've reached the stopping condition...
+      if (!element.repeat && checkStoppingCondition(element)) {
         element.onComplete();
+        element.state.complete = true;
+        // If repeat is specified and we've reached the repeat count.
+      } else if (element.repeat === element.state.repeatCount - 1) {
+        element.onComplete(element.state.playState);
         element.state.complete = true;
       } else {
         element.onUpdate({

--- a/src/rAF/update.ts
+++ b/src/rAF/update.ts
@@ -57,7 +57,7 @@ export function update<C>({
       // Conditions for stopping the physics animation.
       // If no repeat is specified and we've reached the stopping condition...
       if (
-        (typeof element.repeat !== 'number' || element.repeat === 0) &&
+        (typeof element.repeat !== 'number' || element.repeat <= 0) &&
         checkStoppingCondition(element)
       ) {
         element.onComplete();

--- a/src/rAF/update.ts
+++ b/src/rAF/update.ts
@@ -54,17 +54,13 @@ export function update<C>({
         element.state.mover = applyForceForStep(element);
       }
 
-      // Conditions for stopping the physics animation.
-      // If no repeat is specified and we've reached the stopping condition...
-      if (
+      const shouldComplete =
         (typeof element.repeat !== 'number' || element.repeat <= 0) &&
-        checkStoppingCondition(element)
-      ) {
+        checkStoppingCondition(element);
+      const repetitionsEclipsed = element.repeat === element.state.repeatCount;
+
+      if (shouldComplete || repetitionsEclipsed) {
         element.onComplete();
-        element.state.complete = true;
-        // If repeat is specified and we've reached the repeat count.
-      } else if (element.repeat === element.state.repeatCount) {
-        element.onComplete(element.state.playState);
         element.state.complete = true;
       } else {
         element.onUpdate({

--- a/stories/useFluidResistance.stories.tsx
+++ b/stories/useFluidResistance.stories.tsx
@@ -143,14 +143,14 @@ export const FluidResistanceBoxShadow: FC = () => {
       boxShadow: '20px 20px 50px teal, -20px -20px 50px orange',
     },
     to: {
-      boxShadow: '-20px -20px 0px orange, 20px 20px 0px teal',
+      boxShadow: '-20px -20px 0px teal, 20px 20px 0px orange',
     },
     config: {
       mass: number('mass', 20),
       rho: number('rho', 20),
       area: number('area', 20),
       cDrag: number('cDrag', 0.1),
-      settle: boolean('settle', true),
+      settle: boolean('settle', false),
     },
     repeat: Infinity,
   });
@@ -161,19 +161,19 @@ export const FluidResistanceBoxShadow: FC = () => {
 export const FluidResistanceRepeatCount: FC = () => {
   const [props] = useFluidResistance<HTMLDivElement>({
     from: {
-      boxShadow: '20px 20px 0px teal, -20px -20px 0px orange',
+      transform: 'translateX(0px)',
     },
     to: {
-      boxShadow: '-20px -20px 0px orange, 20px 20px 0px teal',
+      transform: 'translateX(100px)',
     },
     config: {
-      mass: number('mass', 20),
+      mass: number('mass', 10),
       rho: number('rho', 20),
       area: number('area', 20),
       cDrag: number('cDrag', 0.1),
       settle: boolean('settle', false),
     },
-    repeat: 5,
+    repeat: 2,
   });
 
   return <div className="mover mover--purple" {...props} />;


### PR DESCRIPTION
Fix #124 

This PR addresses some of the issues @boygirl pointed out, specifically:

- **An even number for `repeat` leads to an incorrect "jump" to the `to` value.** This was caused by the fact that we didn't take into account the `playState` (i.e. direction) of an animation when calling `onComplete`. If an animation is running with `playState = PlayState.Forward` when it eclipses the `repeatCount`, it should stop at its `to` value. Conversely, if an animation is running with `playState = PlayState.Reverse` when it eclipses the `repeatCount`, it should stop at its `from` value.
- **Supplying a `string` to `repeat` leads to animations that continue past their `to` value.** This was caused by the fact that 1) we don't type check user input in source, since we rely on TypeScript, and 2) our interpolators do not clamp values, so we keep interpolating past the `to` value and keep updating the frame loop.

In addition, it fixes the behavior of the `repeat` API to behave _exactly_ like `framer-motion` (and how I originally intended it to work). The key change:

- The number specified in `repeat` is the number of _additional_ animation cycles after the first. So, for example, with the following configuration:

```typescript
{
  from: {
    transform: 'translateX(0px)'
  },
  to: {
    transform: 'translateX(100px)'
  },
  repeat: 2,
}
```

the element would move from 0px to 100px (initial animation), from 100px back to 0px (1st repeat), and from 0px to 100px (2nd repeat), completing at `transform: translateX(100px)`.