### PR TITLE
Docs: move interactive Demo to codersandbox

### DIFF
--- a/docs/src/screens/gallery/gallery-preview.js
+++ b/docs/src/screens/gallery/gallery-preview.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Link, useLocation } from 'react-router-dom';
 import { LiveProvider, LivePreview } from 'react-live';
 
 import { scope, removeImportFromPreview } from '../../utils/live-preview';
@@ -28,7 +27,7 @@ const StyledPreview = styled(LivePreview)`
   background: ${(p) => p.theme.colors.textLight};
 `;
 
-const StyledPreviewTitle = styled(Link)`
+const StyledPreviewTitle = styled.a`
   display: flex;
   align-items: center;
   font-size: ${(p) => p.theme.fontSizes.small};
@@ -55,12 +54,7 @@ const StyledPreviewTitle = styled(Link)`
   }
 `;
 
-const GalleryPreview = ({ title, code, slug }) => {
-  const location = useLocation();
-  const to = `${location.pathname}${
-    location.pathname.endsWith('/') ? slug : '/' + slug
-  }`;
-
+const GalleryPreview = ({ title, code, demoLink }) => {
   return (
     <StyledCard>
       <LiveProvider
@@ -70,7 +64,13 @@ const GalleryPreview = ({ title, code, slug }) => {
       >
         <StyledPreview />
       </LiveProvider>
-      <StyledPreviewTitle to={to}>{title}</StyledPreviewTitle>
+      <StyledPreviewTitle
+        href={demoLink}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {title}
+      </StyledPreviewTitle>
     </StyledCard>
   );
 };
@@ -78,7 +78,7 @@ const GalleryPreview = ({ title, code, slug }) => {
 GalleryPreview.propTypes = {
   title: PropTypes.string.isRequired,
   code: PropTypes.string.isRequired,
-  slug: PropTypes.string.isRequired,
+  demoLink: PropTypes.string.isRequired,
 };
 
 export default GalleryPreview;

--- a/docs/src/screens/gallery/index.js
+++ b/docs/src/screens/gallery/index.js
@@ -101,8 +101,13 @@ const Gallery = () => {
           </GalleryNav>
         </GalleryHeader>
         <GalleryGrid>
-          {samples('gallery-preview').map(({ title, code, slug }) => (
-            <GalleryPreview key={title} title={title} code={code} slug={slug} />
+          {samples('gallery-preview').map(({ title, code, demoLink }) => (
+            <GalleryPreview
+              key={title}
+              title={title}
+              code={code}
+              demoLink={demoLink}
+            />
           ))}
         </GalleryGrid>
       </Container>

--- a/docs/src/screens/gallery/samples/basic.js
+++ b/docs/src/screens/gallery/samples/basic.js
@@ -29,4 +29,5 @@ export const basic = (context) => ({
   title: 'Basic Transform',
   slug: 'basic-transform/',
   code: code(context),
+  demoLink: 'https://codesandbox.io/s/renature-basic-transform-21u2w',
 });

--- a/docs/src/screens/gallery/samples/box-shadow.js
+++ b/docs/src/screens/gallery/samples/box-shadow.js
@@ -34,4 +34,5 @@ export const boxShadow = (context) => ({
   title: 'Box Shadow',
   slug: 'box-shadow/',
   code: code(context),
+  demoLink: 'https://codesandbox.io/s/renature-box-shadow-1ytkc',
 });

--- a/docs/src/screens/gallery/samples/controlled.js
+++ b/docs/src/screens/gallery/samples/controlled.js
@@ -43,4 +43,5 @@ export const controlled = (context) => ({
   title: 'Controlled Animations',
   slug: 'controlled-animations/',
   code: code(context),
+  demoLink: 'https://codesandbox.io/s/renature-controlled-animations-4rwe3',
 });

--- a/docs/src/screens/gallery/samples/grouped-animations.js
+++ b/docs/src/screens/gallery/samples/grouped-animations.js
@@ -48,4 +48,5 @@ export const groupedAnimations = (context) => ({
   title: 'Grouped Animations',
   slug: 'grouped-animations/',
   code: code(context),
+  demoLink: 'https://codesandbox.io/s/renature-grouped-animations-drimw',
 });

--- a/docs/src/screens/gallery/samples/multiple-properties.js
+++ b/docs/src/screens/gallery/samples/multiple-properties.js
@@ -37,4 +37,5 @@ export const multipleProperties = (context) => ({
   code: code(context),
   title: 'Multiple CSS Properties',
   slug: 'multiple-css-properties/',
+  demoLink: 'https://codesandbox.io/s/renature-multiple-css-properties-h3oep',
 });

--- a/docs/src/screens/gallery/samples/orbit.js
+++ b/docs/src/screens/gallery/samples/orbit.js
@@ -54,4 +54,5 @@ export const orbit = (context) => ({
   title: 'Orbit',
   slug: 'orbit/',
   code: code(context),
+  demoLink: 'https://codesandbox.io/s/renature-orbit-7w6z0',
 });

--- a/docs/src/screens/gallery/samples/path-tracing.js
+++ b/docs/src/screens/gallery/samples/path-tracing.js
@@ -105,4 +105,5 @@ export const pathTracing = (context) => ({
   code: code(context),
   title: 'SVG Path Tracing',
   slug: 'svg-path-tracing/',
+  demoLink: 'https://codesandbox.io/s/renature-svg-path-tracing-0n8s9',
 });

--- a/docs/src/screens/gallery/samples/set.js
+++ b/docs/src/screens/gallery/samples/set.js
@@ -46,4 +46,5 @@ export const set = (context) => ({
   code: code(context),
   title: 'controller.set',
   slug: 'controller-set/',
+  demoLink: 'https://codesandbox.io/s/renature-controllerset-6dyj1',
 });


### PR DESCRIPTION
This PR updates the gallery preview components to point to external CoderSandbox links instead of the internal LivePreview versions. Changes include:
* Update each demo preview file to include a URL to relevant CoderSandbox version
* Modify the interface for the GalleryPreview component to accept a `demoLink` and remove the `stub` prop
* Switch from react-router-dom `Link` to basic `a` tag for external link