### PR TITLE
feat: add API for accessible animations

### DIFF
--- a/__tests__/hooks/usePrefersReducedMotion.spec.ts
+++ b/__tests__/hooks/usePrefersReducedMotion.spec.ts
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { usePrefersReducedMotion } from '../../src/hooks/usePrefersReducedMotion';
+
+describe('usePrefersReducedMotion', () => {
+  it.each([
+    { query: 'no-preference', prefersReducedMotion: false },
+    { query: 'reduce', prefersReducedMotion: true },
+  ])(
+    'should return a boolean indicating whether or not the user prefers reduced motion',
+    ({ query, prefersReducedMotion }) => {
+      window.matchMedia = jest.fn().mockImplementation((q) => ({
+        matches: q === `(prefers-reduced-motion: ${query})`,
+        media: '',
+        onchange: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }));
+
+      const { result } = renderHook(() => usePrefersReducedMotion());
+      expect(result.current).toBe(prefersReducedMotion);
+    }
+  );
+
+  it.each([
+    { query: 'no-preference', prefersReducedMotion: false },
+    { query: 'reduce', prefersReducedMotion: true },
+  ])(
+    'should set up listeners for changes to the reduced motion preference',
+    ({ query, prefersReducedMotion }) => {
+      const addEventListenerMock = jest.fn();
+      const removeEventListenerMock = jest.fn();
+
+      window.matchMedia = jest.fn().mockImplementation((q) => ({
+        matches: q === `(prefers-reduced-motion: ${query})`,
+        media: '',
+        onchange: jest.fn(),
+        addEventListener: addEventListenerMock,
+        removeEventListener: removeEventListenerMock,
+      }));
+
+      const { result, unmount } = renderHook(() => usePrefersReducedMotion());
+      expect(result.current).toBe(prefersReducedMotion);
+
+      expect(addEventListenerMock).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      expect(addEventListenerMock).toHaveBeenCalledTimes(1);
+      expect(removeEventListenerMock).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/__tests__/hooks/usePrefersReducedMotion.spec.ts
+++ b/__tests__/hooks/usePrefersReducedMotion.spec.ts
@@ -3,6 +3,15 @@ import { renderHook } from '@testing-library/react-hooks';
 import { usePrefersReducedMotion } from '../../src/hooks/usePrefersReducedMotion';
 
 describe('usePrefersReducedMotion', () => {
+  afterAll(() => {
+    // jsdom does not implement window.matchMedia, so we mock it in this suite.
+    // Ensure this is reset to undefined at the end of the suite.
+    // TS will complain about the assignment to undefined, but we can safely ignore it here.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window.matchMedia = undefined;
+  });
+
   it.each([
     { query: 'no-preference', prefersReducedMotion: false },
     { query: 'reduce', prefersReducedMotion: true },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/addon-knobs": "^6.1.21",
     "@storybook/addons": "^6.1.21",
     "@storybook/react": "^6.1.21",
+    "@testing-library/react-hooks": "^5.1.0",
     "@types/jest": "^26.0.13",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -33,6 +33,10 @@ export interface HooksParams {
   onFrame?: (progress: number) => void;
   onAnimationComplete?: () => void;
   disableHardwareAcceleration?: boolean;
+  reducedMotion?: {
+    from: CSSProperties;
+    to: CSSProperties;
+  };
 }
 
 export enum PlayState {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useFriction';
 export * from './useFrictionGroup';
 export * from './useFluidResistance';
 export * from './useFluidResistanceGroup';
+export * from './usePrefersReducedMotion';

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -96,7 +96,50 @@ export const onComplete = <E extends HTMLElement | SVGElement>({
   onAnimationComplete?.();
 };
 
-interface CheckCacheParams {
+interface DeriveAccessibleFromToParams {
+  prefersReducedMotion: boolean;
+  from: CSSProperties;
+  to: CSSProperties;
+  reducedMotion?: {
+    from: CSSProperties;
+    to: CSSProperties;
+  };
+}
+
+/**
+ * The deriveAccessibleFromTo function determines the correct from / to
+ * combination to use for accessible animations. The algorithm:
+ *
+ * - If a user does not prefer reduced motion, return the base from / to combination.
+ * - If the user does prefer reduced motion and there's a reducedMotion config applied,
+ *   return the reducedMotion config.
+ * - Else, immediately animate to the "to" state on the first frame to avoid animations
+ *   when a user explicitly prefers reduced motion.
+ */
+export const deriveAccessibleFromTo = ({
+  prefersReducedMotion,
+  from,
+  to,
+  reducedMotion,
+}: DeriveAccessibleFromToParams): CSSPairs => {
+  if (!prefersReducedMotion) {
+    return {
+      from,
+      to,
+    };
+  }
+
+  if (prefersReducedMotion && reducedMotion) {
+    return reducedMotion;
+  }
+
+  return {
+    from: to,
+    to,
+  };
+};
+
+interface CheckAnimationCacheParams {
   cache: MutableRefObject<AnimationCache>;
   index: number;
   from: CSSProperties;
@@ -106,7 +149,7 @@ interface CheckCacheParams {
 /**
  * The checkAnimationCache functions inspects the hook's local animation cache to see
  * if there are animation properties applied. It also checks if the cached properties
- * match that of the to configuration, signaling it's safe to animate. Otherwise, use
+ * match that of the "to" configuration, signaling it's safe to animate. Otherwise, use
  * the from and to specified in the configuration.
  */
 export const checkAnimationCache = ({
@@ -114,10 +157,15 @@ export const checkAnimationCache = ({
   index,
   from,
   to,
-}: CheckCacheParams): CSSPairs => {
+}: CheckAnimationCacheParams): CSSPairs => {
   const cachedFrom = cache.current.get(index);
 
-  if (cachedFrom && Object.keys(cachedFrom) === Object.keys(to)) {
+  if (
+    cachedFrom &&
+    Object.keys(cachedFrom).every((k) =>
+      Object.prototype.hasOwnProperty.call(to, k)
+    )
+  ) {
     return {
       from: cachedFrom,
       to,

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -1,7 +1,7 @@
-import type { RefObject, MutableRefObject } from 'react';
+import type { RefObject, MutableRefObject, CSSProperties } from 'react';
 
 import { AnimationCache, PlayState, VectorSetter } from '../animation';
-import type { InterpolatedResult } from '../parsers';
+import type { CSSPairs, InterpolatedResult } from '../parsers';
 
 interface OnUpdateParams<E extends HTMLElement | SVGElement> {
   interpolators: InterpolatedResult<any, any>[];
@@ -94,4 +94,32 @@ export const onComplete = <E extends HTMLElement | SVGElement>({
   });
 
   onAnimationComplete?.();
+};
+
+interface CheckCacheParams {
+  cache: MutableRefObject<AnimationCache>;
+  index: number;
+  from: CSSProperties;
+  to: CSSProperties;
+}
+
+export const checkAnimationCache = ({
+  cache,
+  index,
+  from,
+  to,
+}: CheckCacheParams): CSSPairs => {
+  const cachedFrom = cache.current.get(index);
+
+  if (cachedFrom && Object.keys(cachedFrom) === Object.keys(to)) {
+    return {
+      from: cachedFrom,
+      to,
+    };
+  }
+
+  return {
+    from,
+    to,
+  };
 };

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -103,6 +103,12 @@ interface CheckCacheParams {
   to: CSSProperties;
 }
 
+/**
+ * The checkAnimationCache functions inspects the hook's local animation cache to see
+ * if there are animation properties applied. It also checks if the cached properties
+ * match that of the to configuration, signaling it's safe to animate. Otherwise, use
+ * the from and to specified in the configuration.
+ */
 export const checkAnimationCache = ({
   cache,
   index,

--- a/src/hooks/useFluidResistance.ts
+++ b/src/hooks/useFluidResistance.ts
@@ -17,6 +17,7 @@ export const useFluidResistance = <E extends HTMLElement | SVGElement = any>({
   onFrame,
   onAnimationComplete,
   disableHardwareAcceleration,
+  reducedMotion,
 }: UseFluidResistanceParams): [{ ref: RefObject<E> }, Controller] => {
   const [props, controller] = useFluidResistanceGroup(1, () => ({
     from,
@@ -28,6 +29,7 @@ export const useFluidResistance = <E extends HTMLElement | SVGElement = any>({
     onFrame,
     onAnimationComplete,
     disableHardwareAcceleration,
+    reducedMotion,
   }));
 
   return [props[0], controller];

--- a/src/hooks/useForceGroup.ts
+++ b/src/hooks/useForceGroup.ts
@@ -17,7 +17,12 @@ import {
   AnimationGroup,
 } from '../animation';
 
-import { checkAnimationCache, onComplete, onUpdate } from './shared';
+import {
+  checkAnimationCache,
+  deriveAccessibleFromTo,
+  onComplete,
+  onUpdate,
+} from './shared';
 import { usePrefersReducedMotion } from './usePrefersReducedMotion';
 
 type UseForceGroupConfig<C> = CSSPairs & HooksParams & { config?: C };
@@ -54,10 +59,14 @@ export const useForceGroup = <C, E extends HTMLElement | SVGElement>({
         // Create the ref to store the animating element.
         const ref = createRef<E>();
 
-        const { from, to } =
-          props.reducedMotion && prefersReducedMotion
-            ? props.reducedMotion
-            : { from: props.from, to: props.to };
+        // Derive the from and to values to use, taking into account both an end
+        // user's reduced motion preference and the specified reducedMotion config.
+        const { from, to } = deriveAccessibleFromTo({
+          prefersReducedMotion,
+          from: props.from,
+          to: props.to,
+          reducedMotion: props.reducedMotion,
+        });
 
         // Derive interpolator functions for the supplied CSS properties.
         // Read from the cache, if populated, to determine the from value.

--- a/src/hooks/useFriction.ts
+++ b/src/hooks/useFriction.ts
@@ -14,6 +14,7 @@ export const useFriction = <E extends HTMLElement | SVGElement = any>({
   onFrame,
   onAnimationComplete,
   disableHardwareAcceleration = false,
+  reducedMotion,
 }: UseFrictionParams): [{ ref: RefObject<E> }, Controller] => {
   const [props, controller] = useFrictionGroup<E>(1, () => ({
     from,
@@ -25,6 +26,7 @@ export const useFriction = <E extends HTMLElement | SVGElement = any>({
     onFrame,
     onAnimationComplete,
     disableHardwareAcceleration,
+    reducedMotion,
   }));
 
   return [props[0], controller];

--- a/src/hooks/useGravity.ts
+++ b/src/hooks/useGravity.ts
@@ -14,6 +14,7 @@ export const useGravity = <E extends HTMLElement | SVGElement = any>({
   onFrame,
   onAnimationComplete,
   disableHardwareAcceleration,
+  reducedMotion,
 }: UseGravityParams): [{ ref: RefObject<E> }, Controller] => {
   const [props, controller] = useGravityGroup(1, () => ({
     from,
@@ -25,6 +26,7 @@ export const useGravity = <E extends HTMLElement | SVGElement = any>({
     onFrame,
     onAnimationComplete,
     disableHardwareAcceleration,
+    reducedMotion,
   }));
 
   return [props[0], controller];

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+const query = '(prefers-reduced-motion: no-preference)';
+
+const getInitialState = () =>
+  typeof window === 'undefined'
+    ? true
+    : !window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+
+export const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    getInitialState()
+  );
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(!event.matches);
+    };
+
+    mediaQueryList.addEventListener('change', listener);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', listener);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+};

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -3,9 +3,7 @@ import { useState, useEffect } from 'react';
 const query = '(prefers-reduced-motion: no-preference)';
 
 const getInitialState = () =>
-  typeof window === 'undefined'
-    ? true
-    : !window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+  typeof window === 'undefined' ? true : !window.matchMedia(query).matches;
 
 export const usePrefersReducedMotion = (): boolean => {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -118,6 +118,14 @@ export const FrictionInfinite: FC = () => {
       background: '#a04ad9',
       transform: 'scale(1.5) rotate(720deg)',
     },
+    reducedMotion: {
+      from: {
+        opacity: 0,
+      },
+      to: {
+        opacity: 1,
+      },
+    },
     config: {
       mu: number('mu', 0.5),
       mass: number('mass', 300),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4069,6 +4069,18 @@
     resolve-from "^5.0.0"
     store2 "^2.7.1"
 
+"@testing-library/react-hooks@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz#6014b7536d0e9427a1e73ce1d073c49a6af5fb3b"
+  integrity sha512-ChRyyA14e0CeVkWGp24v8q/IiWUqH+B8daRx4lGZme4dsudmMNWz+Qo2Q2NzbD2O5rAVXh2hSbS/KTKeqHYhkw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -4323,6 +4335,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.2.tgz#35654cf6c49ae162d5bc90843d5437dc38008d43"
+  integrity sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.9.8":
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
@@ -4337,6 +4356,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.9.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.16.tgz#4f12515707148b1f53a8eaa4341dae5dfefb066d"
@@ -4344,6 +4370,15 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@>=16.9.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
 
 "@types/react@^16.9.43":
   version "16.9.43"
@@ -4359,6 +4394,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -6679,6 +6719,11 @@ csstype@^2.6.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
 
+csstype@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
+  integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -7955,6 +8000,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -12273,6 +12323,13 @@ react-draggable@^4.0.3:
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.1.tgz#932c5ca5cbab8ec4fe37fd7b415aa5c3a47597e7"
+  integrity sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
This PR is an exciting one — it adds support for accessible animations! You can now specify a `reducedMotion` configuration and, if a user prefers reduced motion in their OS accessibility settings, they'll see the animation using the `from` and `to` specified in `reducedMotion`.

The implementation of `usePrefersReducedMotion` is lightly modified from [Josh Comeau's excellent blog post](https://www.joshwcomeau.com/react/prefers-reduced-motion/) on the subject. What I appreciate about Josh's approach is that it also ensures that folks using devices / OSes that don't support this setting will still get the reduced motion animation (if specified). In this way, we go for accessible animations as the _default_ behavior rather than the _opt in_ behavior.

To use this API, users of `renature` can specify something like the following:

```typescript
export const FrictionInfinite: FC = () => {
  const [props] = useFriction<HTMLDivElement>({
    from: {
      background: '#f25050',
      transform: 'scale(1) rotate(0deg)',
    },
    to: {
      background: '#a04ad9',
      transform: 'scale(1.5) rotate(720deg)',
    },
    reducedMotion: {
      from: {
        opacity: 0,
      },
      to: {
        opacity: 1,
      },
    },
    repeat: Infinity,
  });
  return <div className="mover mover--red" {...props} />;
};
```

Lastly, this implementation also sets up event listeners to listen for changes to the `prefers-reduced-motion` setting. This means that an animation will alter itself mid-execution of this preference changes!

![20210323_reduced_motion](https://user-images.githubusercontent.com/19421190/112356890-42dcaa80-8c8c-11eb-99ea-baaf451a1c8b.gif)
