### PR TITLE
feat: pass physics values to onFrame callback

### DIFF
--- a/__tests__/rAF/update.spec.ts
+++ b/__tests__/rAF/update.spec.ts
@@ -102,6 +102,7 @@ describe('update', () => {
     const mockMoverState: Partial<Entity> = {
       velocity: [2, 0],
       position: [5, 0],
+      acceleration: [-1.5, -2],
     };
 
     const element: StatefulAnimatingElement<

--- a/src/animation/gravity2D.ts
+++ b/src/animation/gravity2D.ts
@@ -112,6 +112,7 @@ export function gravity2D({
     onUpdate({
       position: state.mover.position,
       velocity: state.mover.velocity,
+      acceleration: state.mover.acceleration,
     });
   };
 

--- a/src/animation/gravity2D.ts
+++ b/src/animation/gravity2D.ts
@@ -23,7 +23,6 @@ export interface Gravity2DParams extends AnimationParams {
     };
     G?: number;
   };
-  onUpdate: VectorSetter;
 }
 
 export interface Gravity2DController extends Controller {

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -9,7 +9,7 @@ interface MotionVectors {
   acceleration: Vector<number>;
 }
 
-export type VectorSetter = (values: MotionVectors) => void;
+export type VectorSetter = (motionVectors: MotionVectors) => void;
 
 export type Listener = (
   timestamp: DOMHighResTimeStamp,

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -5,7 +5,8 @@ import type { entity as Entity } from '../forces';
 
 export type VectorSetter = (values: {
   position: Vector<number>;
-  velocity?: Vector<number>;
+  velocity: Vector<number>;
+  acceleration: Vector<number>;
 }) => void;
 
 export type Listener = (
@@ -26,11 +27,18 @@ export interface AnimationParams {
   onComplete: () => void;
 }
 
+interface OnFrameParams {
+  progress: number;
+  position: Vector<number>;
+  velocity: Vector<number>;
+  acceleration: Vector<number>;
+}
+
 export interface HooksParams {
   pause?: boolean;
   delay?: number;
   repeat?: number;
-  onFrame?: (progress: number) => void;
+  onFrame?: (onFrameParams: OnFrameParams) => void;
   onAnimationComplete?: () => void;
   disableHardwareAcceleration?: boolean;
   reducedMotion?: {

--- a/src/animation/types.ts
+++ b/src/animation/types.ts
@@ -3,11 +3,13 @@ import type { CSSProperties, RefObject } from 'react';
 import type { vector as Vector } from '../core';
 import type { entity as Entity } from '../forces';
 
-export type VectorSetter = (values: {
+interface MotionVectors {
   position: Vector<number>;
   velocity: Vector<number>;
   acceleration: Vector<number>;
-}) => void;
+}
+
+export type VectorSetter = (values: MotionVectors) => void;
 
 export type Listener = (
   timestamp: DOMHighResTimeStamp,
@@ -27,18 +29,11 @@ export interface AnimationParams {
   onComplete: () => void;
 }
 
-interface OnFrameParams {
-  progress: number;
-  position: Vector<number>;
-  velocity: Vector<number>;
-  acceleration: Vector<number>;
-}
-
 export interface HooksParams {
   pause?: boolean;
   delay?: number;
   repeat?: number;
-  onFrame?: (onFrameParams: OnFrameParams) => void;
+  onFrame?: (progress: number, motionVectors: MotionVectors) => void;
   onAnimationComplete?: () => void;
   disableHardwareAcceleration?: boolean;
   reducedMotion?: {

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -1,6 +1,11 @@
 import type { RefObject, MutableRefObject, CSSProperties } from 'react';
 
-import { AnimationCache, PlayState, VectorSetter } from '../animation';
+import {
+  AnimationCache,
+  HooksParams,
+  PlayState,
+  VectorSetter,
+} from '../animation';
 import type { CSSPairs, InterpolatedResult } from '../parsers';
 
 interface OnUpdateParams<E extends HTMLElement | SVGElement> {
@@ -10,7 +15,7 @@ interface OnUpdateParams<E extends HTMLElement | SVGElement> {
   ref: RefObject<E>;
   i: number;
   cache: MutableRefObject<AnimationCache>;
-  onFrame?: (progress: number) => void;
+  onFrame?: HooksParams['onFrame'];
 }
 
 /**
@@ -26,7 +31,11 @@ export const onUpdate = <E extends HTMLElement | SVGElement>({
   i,
   cache,
   onFrame,
-}: OnUpdateParams<E>): VectorSetter => ({ position }) => {
+}: OnUpdateParams<E>): VectorSetter => ({
+  position,
+  velocity,
+  acceleration,
+}) => {
   interpolators.forEach(({ interpolator, property, values }) => {
     const value = interpolator({
       range: [0, maxPosition],
@@ -40,7 +49,7 @@ export const onUpdate = <E extends HTMLElement | SVGElement>({
 
     if (onFrame) {
       const progress = position[0] / maxPosition;
-      onFrame(progress);
+      onFrame({ progress, position, velocity, acceleration });
     }
 
     // Update the cache of derived animation values.

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -49,7 +49,7 @@ export const onUpdate = <E extends HTMLElement | SVGElement>({
 
     if (onFrame) {
       const progress = position[0] / maxPosition;
-      onFrame({ progress, position, velocity, acceleration });
+      onFrame(progress, { position, velocity, acceleration });
     }
 
     // Update the cache of derived animation values.

--- a/src/hooks/useGravity2D.ts
+++ b/src/hooks/useGravity2D.ts
@@ -1,25 +1,19 @@
 import { RefObject, useRef, useMemo, useLayoutEffect } from 'react';
 
-import { vector as Vector } from '../core';
 import {
   Gravity2DParams,
   gravity2D,
   Controller,
   Gravity2DController,
   gravity2DDefaultConfig,
+  VectorSetter,
 } from '../animation';
-
-interface OnFrameParams {
-  position: Vector<number>;
-  velocity: Vector<number>;
-  acceleration: Vector<number>;
-}
 
 type UseGravity2DArgs = {
   config?: Gravity2DParams['config'];
   pause?: boolean;
   delay?: number;
-  onFrame?: (onFrameParams: OnFrameParams) => void;
+  onFrame?: VectorSetter;
   onAnimationComplete?: () => void;
   disableHardwareAcceleration?: boolean;
 };

--- a/src/hooks/useGravity2D.ts
+++ b/src/hooks/useGravity2D.ts
@@ -1,5 +1,6 @@
 import { RefObject, useRef, useMemo, useLayoutEffect } from 'react';
 
+import { vector as Vector } from '../core';
 import {
   Gravity2DParams,
   gravity2D,
@@ -8,11 +9,17 @@ import {
   gravity2DDefaultConfig,
 } from '../animation';
 
+interface OnFrameParams {
+  position: Vector<number>;
+  velocity: Vector<number>;
+  acceleration: Vector<number>;
+}
+
 type UseGravity2DArgs = {
   config?: Gravity2DParams['config'];
   pause?: boolean;
   delay?: number;
-  onFrame?: () => void;
+  onFrame?: (onFrameParams: OnFrameParams) => void;
   onAnimationComplete?: () => void;
   disableHardwareAcceleration?: boolean;
 };
@@ -40,14 +47,16 @@ export const useGravity2D = <E extends HTMLElement | SVGElement = any>({
     () =>
       gravity2D({
         config,
-        onUpdate: ({ position: [x, y] }) => {
+        onUpdate: ({ position, velocity, acceleration }) => {
           moverRef.current &&
-            (moverRef.current.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)${
+            (moverRef.current.style.transform = `translate(${position[0]}px, ${
+              position[1]
+            }px) translate(-50%, -50%)${
               disableHardwareAcceleration ? '' : ' translateZ(0)'
             }`);
 
           if (onFrame) {
-            onFrame();
+            onFrame({ position, velocity, acceleration });
           }
         },
         onComplete: () => {

--- a/src/rAF/update.ts
+++ b/src/rAF/update.ts
@@ -66,6 +66,7 @@ export function update<C>({
         element.onUpdate({
           velocity: element.state.mover.velocity,
           position: element.state.mover.position,
+          acceleration: element.state.mover.acceleration,
         });
       }
     }

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -199,7 +199,7 @@ export const FrictionProgress: FC = () => {
       mass: number('mass', 30),
       initialVelocity: number('velocity', 10),
     },
-    onFrame: (progress) => {
+    onFrame: ({ progress }) => {
       if (progressRef.current) {
         progressRef.current.innerText = `${progress.toFixed(2)}`;
       }

--- a/stories/useFriction.stories.tsx
+++ b/stories/useFriction.stories.tsx
@@ -199,7 +199,7 @@ export const FrictionProgress: FC = () => {
       mass: number('mass', 30),
       initialVelocity: number('velocity', 10),
     },
-    onFrame: ({ progress }) => {
+    onFrame: (progress) => {
       if (progressRef.current) {
         progressRef.current.innerText = `${progress.toFixed(2)}`;
       }


### PR DESCRIPTION
This PR fulfills a feature request from @littlemilkstudio.

The `onFrame` callback now receives the `position`, `velocity`, and `acceleration` values in addition to the `progress` value. For `useGravity2D`, which never received a `progress` value because the orbit animation is infinite by nature, `onFrame` also receives these vectors.

This should make accessing these physics values for us in Three.js / r3f fairly trivial. The API would look something like the following for `useGravity2D`:

```typescript
useGravity2D({
  config: {
    // Physics configuration values
  },
  onFrame: ({ position, velocity, acceleration }) => {
    // Execute some code with the raw physics values, all of which are tuples representing vectors.
  }
});
```

For the other hooks, access will be slightly different. `progress` is the first argument passed to `onFrame`. I didn't want to group `progress` with the physics values to prevent a breaking API change.

```typescript
useFriction({
  config: {
    // Physics configuration values
  },
  onFrame: (progress, { position, velocity, acceleration }) => {
    // Execute some code with the raw physics values, all of which are two tuples representing vectors.
  }
});
```

Hopefully this can be helpful for our Three.js shot! Let me know if there are some missing additional values that would be helpful here.