### PR TITLE
test: add example unit tests for useFriction

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
         }
       }
     ],
+    "@babel/preset-react",
     "@babel/preset-typescript"
   ]
 }

--- a/__tests__/hooks/useFriction.spec.tsx
+++ b/__tests__/hooks/useFriction.spec.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+import { useFriction } from '../../src';
+
+/**
+ * Wait an arbitrary amount of time for the animation to run.
+ * We aren't concerned about what particular state the animation
+ * has reached, just that some animation is actively happening.
+ *
+ * @returns – a Promise that resolves to true after 500ms.
+ */
+const waitForAnimation = async (
+  { timeout, waitForTimeout } = { timeout: 500, waitForTimeout: 1000 }
+): Promise<boolean> =>
+  await waitFor(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(true);
+        }, timeout);
+      }),
+    { timeout: waitForTimeout }
+  );
+
+describe('useFriction', () => {
+  beforeAll(() => {
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      media: '',
+      onchange: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
+  });
+
+  afterAll(() => {
+    window.matchMedia = undefined;
+  });
+
+  it('should return a ref to attach to a DOM or SVG element to support animation', () => {
+    const Component = () => {
+      const [props] = useFriction({
+        from: { transform: 'translateX(0px)' },
+        to: { transform: 'translateX(100px)' },
+      });
+
+      return <div data-testid="node" {...props} />;
+    };
+
+    const { getByTestId } = render(<Component />);
+    const animatingNode = getByTestId('node');
+
+    expect(animatingNode).toHaveStyle({
+      transform: 'translateX(0px) translateZ(0)',
+    });
+  });
+
+  it('should animate the specified property', async () => {
+    const Component = () => {
+      const [props] = useFriction({
+        from: { opacity: 0 },
+        to: { opacity: 1 },
+      });
+
+      return <div data-testid="node" {...props} />;
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    await waitForAnimation();
+
+    const node = getByTestId('node');
+    const currentOpacity = parseFloat(node.style.opacity);
+
+    expect(currentOpacity).toBeGreaterThan(0);
+    expect(currentOpacity).toBeLessThan(1);
+  });
+
+  it('should not animate the specified property if pause is set to true', async () => {
+    const Component = () => {
+      const [props] = useFriction({
+        from: { opacity: 0 },
+        to: { opacity: 1 },
+        pause: true,
+      });
+
+      return <div data-testid="node" {...props} />;
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    await waitForAnimation();
+
+    const node = getByTestId('node');
+    expect(node).not.toHaveAttribute('style');
+  });
+
+  it('should begin animation if pause switches to true on a subsequent render', async () => {
+    const Component = ({ pause }) => {
+      const [props] = useFriction({
+        from: { opacity: 0 },
+        to: { opacity: 1 },
+        pause,
+      });
+
+      return <div data-testid="node" {...props} />;
+    };
+
+    const { getByTestId, rerender } = render(<Component pause />);
+
+    await waitForAnimation();
+
+    const node = getByTestId('node');
+    expect(node).not.toHaveAttribute('style');
+
+    // Re-render Component with pause set to false.
+    rerender(<Component pause={false} />);
+
+    await waitForAnimation();
+
+    const currentOpacity = parseFloat(node.style.opacity);
+
+    expect(currentOpacity).toBeGreaterThan(0);
+    expect(currentOpacity).toBeLessThan(1);
+  });
+
+  it('should animate a delayed animation after the specified delay has elapsed', async () => {
+    const Component = () => {
+      const [props] = useFriction({
+        from: { opacity: 0 },
+        to: { opacity: 1 },
+        delay: 1000,
+      });
+
+      return <div data-testid="node" {...props} />;
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    await waitForAnimation();
+
+    // The animating element should not have animated yet, since waitForAnimation
+    // will only wait for half a second by default.
+    const node = getByTestId('node');
+    expect(node).not.toHaveAttribute('style');
+
+    // Wait an additional full second. By this point, 1500 seconds will have elapsed,
+    // meaning that the 1000 ms delay will be exceeded and the animation should be running.
+    await waitForAnimation({ timeout: 1000, waitForTimeout: 1500 });
+
+    const currentOpacity = parseFloat(node.style.opacity);
+
+    expect(currentOpacity).toBeGreaterThan(0);
+    expect(currentOpacity).toBeLessThan(1);
+  });
+
+  it('should not apply translateZ on an element animating the transform property if disableHardwareAcceleration is true', () => {
+    const Component = () => {
+      const [props] = useFriction({
+        from: { transform: 'translateX(0px)' },
+        to: { transform: 'translateX(100px)' },
+        disableHardwareAcceleration: true,
+      });
+
+      return <div data-testid="node" {...props} />;
+    };
+
+    const { getByTestId } = render(<Component />);
+    const animatingNode = getByTestId('node');
+
+    expect(animatingNode).toHaveStyle({
+      transform: 'translateX(0px)',
+    });
+  });
+});

--- a/__tests__/hooks/useFriction.spec.tsx
+++ b/__tests__/hooks/useFriction.spec.tsx
@@ -38,139 +38,179 @@ describe('useFriction', () => {
     window.matchMedia = undefined;
   });
 
-  it('should return a ref to attach to a DOM or SVG element to support animation', () => {
-    const Component = () => {
-      const [props] = useFriction({
-        from: { transform: 'translateX(0px)' },
-        to: { transform: 'translateX(100px)' },
+  describe('Core API Functionality', () => {
+    it('should return a ref to attach to a DOM or SVG element to support animation', () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+        });
+
+        return <div data-testid="node" {...props} />;
+      };
+
+      const { getByTestId } = render(<Component />);
+      const animatingNode = getByTestId('node');
+
+      expect(animatingNode).toHaveStyle({
+        opacity: 0,
       });
+    });
 
-      return <div data-testid="node" {...props} />;
-    };
+    it('should animate the specified property', async () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+        });
 
-    const { getByTestId } = render(<Component />);
-    const animatingNode = getByTestId('node');
+        return <div data-testid="node" {...props} />;
+      };
 
-    expect(animatingNode).toHaveStyle({
-      transform: 'translateX(0px) translateZ(0)',
+      const { getByTestId } = render(<Component />);
+
+      await waitForAnimation();
+
+      const node = getByTestId('node');
+      const currentOpacity = parseFloat(node.style.opacity);
+
+      expect(currentOpacity).toBeGreaterThan(0);
+      expect(currentOpacity).toBeLessThan(1);
+    });
+
+    it('should not animate the specified property if pause is set to true', async () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+          pause: true,
+        });
+
+        return <div data-testid="node" {...props} />;
+      };
+
+      const { getByTestId } = render(<Component />);
+
+      await waitForAnimation();
+
+      const node = getByTestId('node');
+      expect(node).not.toHaveAttribute('style');
+    });
+
+    it('should begin animation if pause switches to true on a subsequent render', async () => {
+      const Component = ({ pause }) => {
+        const [props] = useFriction({
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+          pause,
+        });
+
+        return <div data-testid="node" {...props} />;
+      };
+
+      const { getByTestId, rerender } = render(<Component pause />);
+
+      await waitForAnimation();
+
+      const node = getByTestId('node');
+      expect(node).not.toHaveAttribute('style');
+
+      // Re-render Component with pause set to false.
+      rerender(<Component pause={false} />);
+
+      await waitForAnimation();
+
+      const currentOpacity = parseFloat(node.style.opacity);
+
+      expect(currentOpacity).toBeGreaterThan(0);
+      expect(currentOpacity).toBeLessThan(1);
+    });
+
+    it('should animate a delayed animation after the specified delay has elapsed', async () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+          delay: 1000,
+        });
+
+        return <div data-testid="node" {...props} />;
+      };
+
+      const { getByTestId } = render(<Component />);
+
+      await waitForAnimation();
+
+      // The animating element should not have animated yet, since waitForAnimation
+      // will only wait for half a second by default.
+      const node = getByTestId('node');
+      expect(node).not.toHaveAttribute('style');
+
+      // Wait an additional full second. By this point, 1500 seconds will have elapsed,
+      // meaning that the 1000 ms delay will be exceeded and the animation should be running.
+      await waitForAnimation({ timeout: 1000, waitForTimeout: 1500 });
+
+      const currentOpacity = parseFloat(node.style.opacity);
+
+      expect(currentOpacity).toBeGreaterThan(0);
+      expect(currentOpacity).toBeLessThan(1);
     });
   });
 
-  it('should animate the specified property', async () => {
-    const Component = () => {
-      const [props] = useFriction({
-        from: { opacity: 0 },
-        to: { opacity: 1 },
+  describe('transform Animations', () => {
+    it('should add translateZ to transform animations by default', () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { transform: 'translateX(0px)' },
+          to: { transform: 'translateX(100px)' },
+        });
+
+        return <div data-testid="node" {...props} />;
+      };
+
+      const { getByTestId } = render(<Component />);
+      const animatingNode = getByTestId('node');
+
+      expect(animatingNode).toHaveStyle({
+        transform: 'translateX(0px) translateZ(0)',
       });
+    });
 
-      return <div data-testid="node" {...props} />;
-    };
+    it('should not apply translateZ to transform animations if disableHardwareAcceleration is true', () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { transform: 'translateX(0px)' },
+          to: { transform: 'translateX(100px)' },
+          disableHardwareAcceleration: true,
+        });
 
-    const { getByTestId } = render(<Component />);
+        return <div data-testid="node" {...props} />;
+      };
 
-    await waitForAnimation();
+      const { getByTestId } = render(<Component />);
+      const animatingNode = getByTestId('node');
 
-    const node = getByTestId('node');
-    const currentOpacity = parseFloat(node.style.opacity);
-
-    expect(currentOpacity).toBeGreaterThan(0);
-    expect(currentOpacity).toBeLessThan(1);
-  });
-
-  it('should not animate the specified property if pause is set to true', async () => {
-    const Component = () => {
-      const [props] = useFriction({
-        from: { opacity: 0 },
-        to: { opacity: 1 },
-        pause: true,
+      expect(animatingNode).toHaveStyle({
+        transform: 'translateX(0px)',
       });
+    });
 
-      return <div data-testid="node" {...props} />;
-    };
+    it('should respect user-supplied values for a transform animation using translateZ', () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { transform: 'scale(1) translateZ(50px)' },
+          to: { transform: 'scale(0) translateX(0px)' },
+        });
 
-    const { getByTestId } = render(<Component />);
+        return <div data-testid="node" {...props} />;
+      };
 
-    await waitForAnimation();
+      const { getByTestId } = render(<Component />);
+      const animatingNode = getByTestId('node');
 
-    const node = getByTestId('node');
-    expect(node).not.toHaveAttribute('style');
-  });
-
-  it('should begin animation if pause switches to true on a subsequent render', async () => {
-    const Component = ({ pause }) => {
-      const [props] = useFriction({
-        from: { opacity: 0 },
-        to: { opacity: 1 },
-        pause,
+      expect(animatingNode).toHaveStyle({
+        transform: 'scale(1) translateZ(50px)',
       });
-
-      return <div data-testid="node" {...props} />;
-    };
-
-    const { getByTestId, rerender } = render(<Component pause />);
-
-    await waitForAnimation();
-
-    const node = getByTestId('node');
-    expect(node).not.toHaveAttribute('style');
-
-    // Re-render Component with pause set to false.
-    rerender(<Component pause={false} />);
-
-    await waitForAnimation();
-
-    const currentOpacity = parseFloat(node.style.opacity);
-
-    expect(currentOpacity).toBeGreaterThan(0);
-    expect(currentOpacity).toBeLessThan(1);
-  });
-
-  it('should animate a delayed animation after the specified delay has elapsed', async () => {
-    const Component = () => {
-      const [props] = useFriction({
-        from: { opacity: 0 },
-        to: { opacity: 1 },
-        delay: 1000,
-      });
-
-      return <div data-testid="node" {...props} />;
-    };
-
-    const { getByTestId } = render(<Component />);
-
-    await waitForAnimation();
-
-    // The animating element should not have animated yet, since waitForAnimation
-    // will only wait for half a second by default.
-    const node = getByTestId('node');
-    expect(node).not.toHaveAttribute('style');
-
-    // Wait an additional full second. By this point, 1500 seconds will have elapsed,
-    // meaning that the 1000 ms delay will be exceeded and the animation should be running.
-    await waitForAnimation({ timeout: 1000, waitForTimeout: 1500 });
-
-    const currentOpacity = parseFloat(node.style.opacity);
-
-    expect(currentOpacity).toBeGreaterThan(0);
-    expect(currentOpacity).toBeLessThan(1);
-  });
-
-  it('should not apply translateZ on an element animating the transform property if disableHardwareAcceleration is true', () => {
-    const Component = () => {
-      const [props] = useFriction({
-        from: { transform: 'translateX(0px)' },
-        to: { transform: 'translateX(100px)' },
-        disableHardwareAcceleration: true,
-      });
-
-      return <div data-testid="node" {...props} />;
-    };
-
-    const { getByTestId } = render(<Component />);
-    const animatingNode = getByTestId('node');
-
-    expect(animatingNode).toHaveStyle({
-      transform: 'translateX(0px)',
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.10.1",
     "@babel/plugin-transform-object-assign": "^7.10.1",
     "@babel/preset-env": "^7.10.1",
+    "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.10.1",
     "@glennsl/bs-jest": "^0.5.1",
     "@rollup/plugin-buble": "^0.21.0",
@@ -46,6 +47,8 @@
     "@storybook/addon-knobs": "^6.1.21",
     "@storybook/addons": "^6.1.21",
     "@storybook/react": "^6.1.21",
+    "@testing-library/jest-dom": "^5.12.0",
+    "@testing-library/react": "^11.2.7",
     "@testing-library/react-hooks": "^5.1.0",
     "@types/jest": "^26.0.13",
     "@types/react": "^16.9.43",
@@ -82,7 +85,7 @@
   "jest": {
     "testMatch": [
       "<rootDir>/__tests__/**/*_test.bs.js",
-      "<rootDir>/__tests__/**/*.spec.ts"
+      "<rootDir>/__tests__/**/*.spec.ts?(x)"
     ],
     "transform": {
       "^.+\\.jsx?$": "<rootDir>/scripts/jest-transform-esm.js",
@@ -94,6 +97,9 @@
     "coveragePathIgnorePatterns": [
       ".gen.tsx",
       "/__tests__/test-utils"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/setupTests.ts"
     ]
   },
   "prettier": {

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,10 @@
     "strict": true,
     "target": "esnext"
   },
-  "include": ["src/**/*", "__tests__/**/*.ts", "stories/**/*.tsx"]
+  "include": [
+    "src/**/*",
+    "__tests__/**/*.ts",
+    "stories/**/*.tsx",
+    "setupTests.ts"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,6 +864,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
   integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
+
 "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
@@ -2167,7 +2172,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx-development@^7.12.12":
+"@babel/plugin-transform-react-jsx-development@^7.12.12", "@babel/plugin-transform-react-jsx-development@^7.12.17":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.17.tgz#f510c0fa7cd7234153539f9a362ced41a5ca1447"
   integrity sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==
@@ -2209,6 +2214,17 @@
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-jsx" "^7.12.13"
     "@babel/types" "^7.13.12"
+
+"@babel/plugin-transform-react-jsx@^7.13.12":
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.3.tgz#0e26597805cf0862da735f264550933c38babb66"
+  integrity sha512-uuxuoUNVhdgYzERiHHFkE4dWoJx+UFVyuAl0aqN8P2/AKFHwqgUC5w2+4/PjpKXJsFgBlYAFXlUmDQ3k3DUkXw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/types" "^7.14.2"
 
 "@babel/plugin-transform-react-jsx@^7.9.1":
   version "7.10.4"
@@ -2719,6 +2735,18 @@
     "@babel/plugin-transform-react-jsx-development" "^7.12.12"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
+"@babel/preset-react@^7.13.13":
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.13.13.tgz#fa6895a96c50763fe693f9148568458d5a839761"
+  integrity sha512-gx+tDLIE06sRjKJkVtpZ/t3mzCDOnPG+ggHZG9lffUbX8+wC739x20YQc9V35Do6ZAxaUc/HhVHIiOzz5MvDmA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-validator-option" "^7.12.17"
+    "@babel/plugin-transform-react-display-name" "^7.12.13"
+    "@babel/plugin-transform-react-jsx" "^7.13.12"
+    "@babel/plugin-transform-react-jsx-development" "^7.12.17"
+    "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
+
 "@babel/preset-typescript@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz#87705a72b1f0d59df21c179f7c3d2ef4b16ce192"
@@ -2754,6 +2782,14 @@
     make-dir "^2.1.0"
     pirates "^4.0.0"
     source-map-support "^0.5.16"
+
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz#6bf5fbc0b961f8e3202888cb2cd0fb7a0a9a3f66"
+  integrity sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime@7.9.0":
   version "7.9.0"
@@ -2794,6 +2830,13 @@
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.9.2":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2960,6 +3003,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.14.2":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.4.tgz#bfd6980108168593b38b3eb48a24aa026b919bc0"
+  integrity sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.3.3":
@@ -3561,6 +3612,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4069,6 +4131,34 @@
     resolve-from "^5.0.0"
     store2 "^2.7.1"
 
+"@testing-library/dom@^7.28.1":
+  version "7.31.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.0.tgz#938451abd3ca27e1b69bb395d4a40759fd7f5b3b"
+  integrity sha512-0X7ACg4YvTRDFMIuTOEj6B4NpN7i3F/4j5igOcTI5NC5J+N4TribNdErCHOZF1LBWhhcyfwxelVwvoYNMUXTOA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/jest-dom@^5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.12.0.tgz#6a5d340b092c44b7bce17a4791b47d9bc2c61443"
+  integrity sha512-N9Y82b2Z3j6wzIoAqajlKVF1Zt7sOH0pPee0sUHXHc5cv2Fdn23r+vpWm0MBBoGJtPOly5+Bdx1lnc3CD+A+ow==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react-hooks@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz#6014b7536d0e9427a1e73ce1d073c49a6af5fb3b"
@@ -4081,10 +4171,23 @@
     filter-console "^0.1.1"
     react-error-boundary "^3.1.0"
 
+"@testing-library/react@^11.2.7":
+  version "11.2.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
+  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
+  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
 "@types/babel__core@^7.0.0":
   version "7.1.9"
@@ -4220,6 +4323,14 @@
   integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@*":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
 
 "@types/jest@^26.0.13":
   version "26.0.13"
@@ -4414,6 +4525,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -4982,6 +5100,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -5158,7 +5284,7 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-atob@^2.1.1:
+atob@^2.1.1, atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
@@ -6121,6 +6247,14 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -6490,6 +6624,11 @@ core-js-compat@^3.8.1, core-js-compat@^3.9.0:
     browserslist "^4.16.3"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.13.0.tgz#9d267fb47d1d7046cfbc05e7b67bb235b6735355"
+  integrity sha512-7VTvXbsMxROvzPAVczLgfizR8CyYnvWPrb1eGrtlZAJfjQWEHLofVfCKljLHdpazTfpaziRORwUH/kfGDKvpdA==
+
 core-js-pure@^3.0.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.0.tgz#c86e14d9316659af04dd54266addc9271f6164f8"
@@ -6674,6 +6813,20 @@ css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -6913,6 +7066,11 @@ diff-sequences@^26.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.3.0.tgz#62a59b1b29ab7fd27cef2a33ae52abe73042d0a2"
   integrity sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -6957,6 +7115,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -9538,6 +9701,16 @@ jest-diff@^25.3.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.3.0"
 
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-diff@^26.4.2:
   version "26.4.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.4.2.tgz#a1b7b303bcc534aabdb3bd4a7caf594ac059f5aa"
@@ -10548,6 +10721,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 magic-string@^0.25.0, magic-string@^0.25.2, magic-string@^0.25.3:
   version "0.25.6"
@@ -11977,6 +12155,16 @@ pretty-format@^25.3.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^26.4.2:
   version "26.4.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
@@ -12574,6 +12762,14 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 refractor@^3.1.0:
   version "3.3.1"
@@ -13382,6 +13578,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.16:
   version "0.5.19"


### PR DESCRIPTION
This PR adds example unit tests for the `useFriction` hook. The goal here is to demonstrate some of the strategy around unit testing this hook so that other contributors can write similar tests to help up coverage and reliability of `renature`.

At first, I planned to use [`@testing-library/react-hooks`](https://github.com/testing-library/react-hooks-testing-library) for these tests, but `renature`'s design introduced a few challenges:

1. A hook like `useFriction` returns a `ref`, which gets attached to a DOM node. Unless we have a DOM node to attach the `ref` to, its value will be `null`. This means we need more structure than `@testing-library/react-hooks` provides — we need to both call the hook _and_ attach it to a DOM node so we can assert on it.
2. We are primarily interested in testing how animating nodes behave from an end user's perspective rather than testing the behavior of the hook itself. For this reason, I opted to use `@testing-library/react` so we can assert on the animating element itself (i.e. particulars of its `style` attribute).

These tests did help me uncover one undesirable edge case with how animations come to an end. I'll write up an issue to track that as well.