### PR TITLE
fix: ensure repeated and non-repeated animations reach full completion

### DIFF
--- a/__tests__/hooks/useFriction.spec.tsx
+++ b/__tests__/hooks/useFriction.spec.tsx
@@ -71,11 +71,33 @@ describe('useFriction', () => {
 
       await waitForAnimation();
 
-      const node = getByTestId('node');
-      const currentOpacity = parseFloat(node.style.opacity);
+      const animatingNode = getByTestId('node');
+      const currentOpacity = parseFloat(animatingNode.style.opacity);
 
       expect(currentOpacity).toBeGreaterThan(0);
       expect(currentOpacity).toBeLessThan(1);
+    });
+
+    it('should complete the animation', async () => {
+      const Component = () => {
+        const [props] = useFriction({
+          from: { opacity: 0 },
+          to: { opacity: 1 },
+        });
+
+        return <div data-testid="node" {...props} />;
+      };
+
+      const { getByTestId } = render(<Component />);
+
+      // Animate for 3 seconds. This should be enough time for the animation
+      // to have reached its completed state.
+      await waitForAnimation({ timeout: 3000, waitForTimeout: 3500 });
+
+      const animatingNode = getByTestId('node');
+      expect(animatingNode).toHaveStyle({
+        opacity: 1,
+      });
     });
 
     it('should not animate the specified property if pause is set to true', async () => {
@@ -93,8 +115,8 @@ describe('useFriction', () => {
 
       await waitForAnimation();
 
-      const node = getByTestId('node');
-      expect(node).not.toHaveAttribute('style');
+      const animatingNode = getByTestId('node');
+      expect(animatingNode).not.toHaveAttribute('style');
     });
 
     it('should begin animation if pause switches to true on a subsequent render', async () => {
@@ -112,15 +134,15 @@ describe('useFriction', () => {
 
       await waitForAnimation();
 
-      const node = getByTestId('node');
-      expect(node).not.toHaveAttribute('style');
+      const animatingNode = getByTestId('node');
+      expect(animatingNode).not.toHaveAttribute('style');
 
       // Re-render Component with pause set to false.
       rerender(<Component pause={false} />);
 
       await waitForAnimation();
 
-      const currentOpacity = parseFloat(node.style.opacity);
+      const currentOpacity = parseFloat(animatingNode.style.opacity);
 
       expect(currentOpacity).toBeGreaterThan(0);
       expect(currentOpacity).toBeLessThan(1);
@@ -143,14 +165,14 @@ describe('useFriction', () => {
 
       // The animating element should not have animated yet, since waitForAnimation
       // will only wait for half a second by default.
-      const node = getByTestId('node');
-      expect(node).not.toHaveAttribute('style');
+      const animatingNode = getByTestId('node');
+      expect(animatingNode).not.toHaveAttribute('style');
 
       // Wait an additional full second. By this point, 1500 seconds will have elapsed,
       // meaning that the 1000 ms delay will be exceeded and the animation should be running.
       await waitForAnimation({ timeout: 1000, waitForTimeout: 1500 });
 
-      const currentOpacity = parseFloat(node.style.opacity);
+      const currentOpacity = parseFloat(animatingNode.style.opacity);
 
       expect(currentOpacity).toBeGreaterThan(0);
       expect(currentOpacity).toBeLessThan(1);

--- a/src/rAF/update.ts
+++ b/src/rAF/update.ts
@@ -59,8 +59,11 @@ export function update<C>({
         checkStoppingCondition(element);
       const repetitionsEclipsed = element.repeat === element.state.repeatCount;
 
-      if (shouldComplete || repetitionsEclipsed) {
+      if (shouldComplete) {
         element.onComplete();
+        element.state.complete = true;
+      } else if (repetitionsEclipsed) {
+        element.onComplete(element.state.playState);
         element.state.complete = true;
       } else {
         element.onUpdate({


### PR DESCRIPTION
Fix #154 

This PR fixes issues with animations not reaching a fully completed state. Previously, `renature` would call the `onComplete` callback without sufficient arguments to determine whether or not the animating element(s) had reached its `to` position (or `from`, in the case of an odd-numbered `repeat` argument).

We now optimize `onComplete` in a few separate ways:

1. The physics in `renature` are of such high precision that reaching our exact `to` value through interpolation is almost impossible. Instead, we're likely to see values like `0.999572643` for an `opacity` animation moving from 0 to 1. We don't need to check whether or not the animating element has reached exactly 1 before setting it to 1 in `onComplete` — we're almost guaranteed to have reached a value of extremely high precision very close to this target `to` state.
2. We used to try to be a bit more clever around how we signaled reaching completion for a finite repeated animation (i.e. an animation with `repeat: <int>` specified) vs. a standard animation moving from `from` to `to` and then completing. This hurt readability and just made the API a bit harder to reason about. We separate out these two cases, since the former will need to account for `playState` in the determination of "completeness" while the latter does not.