### PR TITLE
Chore: add google tag manager

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,6 +32,7 @@
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
+    "react-gtm-module": "^2.0.11",
     "react-is": "^16.13.1",
     "react-live": "^2.2.3",
     "react-router-dom": "^5.2.0",

--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Root, Routes } from 'react-static';
 import { ThemeProvider } from 'styled-components';
 
@@ -6,8 +6,13 @@ import { GlobalStyle } from './styles/global-style';
 import Analytics from './google-analytics';
 import { theme } from './styles/theme';
 import { Loading } from './components/loading';
+import { initGoogleTagManager } from './google-tag-manager';
 
 const App = () => {
+  useEffect(() => {
+    initGoogleTagManager()
+  }, []);
+
   return (
     <Root>
       <ThemeProvider theme={theme}>

--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -10,7 +10,7 @@ import { initGoogleTagManager } from './google-tag-manager';
 
 const App = () => {
   useEffect(() => {
-    initGoogleTagManager()
+    initGoogleTagManager();
   }, []);
 
   return (

--- a/docs/src/google-tag-manager.js
+++ b/docs/src/google-tag-manager.js
@@ -1,0 +1,12 @@
+/**
+ * Google Tag Manager
+ */
+const TagManager = require('react-gtm-module');
+
+export const initGoogleTagManager = () => {
+  if (typeof document === 'undefined') {
+    return;
+  } else {
+    return TagManager.initialize({ gtmId: 'GTM-MD32945' });
+  }
+};

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8356,6 +8356,11 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-gtm-module@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
+  integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
+
 react-helmet@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"


### PR DESCRIPTION
### Description: 
Added google tag manager script

### Issue:
https://github.com/FormidableLabs/formidable.com/issues/2051

### To test: 
- go to `renature>docs` and run `yarn install && yarn build && yarn serve` 
- you should see the google tag manager script/noscript added to `<head>` + `<body>`

